### PR TITLE
Fix dark GUI background in some circumstances

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/Gui7Segment.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/Gui7Segment.java
@@ -92,11 +92,10 @@ public class Gui7Segment extends GuiScreen implements IHoverableHandler {
 
 	@Override
 	public void drawScreen(int x, int y, float par3) {
-		GL11.glColor3f(1, 1, 1);
-
 		hoverable = null;
 		drawDefaultBackground();
 
+		GL11.glColor3f(1F, 1F, 1F);
 		this.mc.getTextureManager().bindTexture(Resources.RESOURCE_GUI_7SEGMENT_BACKGROUND);
 		drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiAssembler.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiAssembler.java
@@ -114,10 +114,10 @@ public class GuiAssembler extends GuiContainer implements IHoverableHandler {
 
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float par1, int x, int y) {
-		GL11.glColor3f(1, 1, 1);
 		drawDefaultBackground();
 		hoverable = null;
 
+		GL11.glColor3f(1F, 1F, 1F);
 		this.mc.getTextureManager().bindTexture(Resources.RESOURCE_GUI_ASSEMBLER_BACKGROUND);
 		drawTexturedModalRect(guiLeft, guiTop, 0, 0, this.xSize, this.ySize);
 


### PR DESCRIPTION
Apparently on my machine GUIs seem to be dark sometimes, unless the background color is set to white before drawing the background.