### PR TITLE
Cleanups and fixes for ContainerAssembler

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerAssembler.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerAssembler.java
@@ -87,15 +87,25 @@ public class ContainerAssembler extends ContainerBase {
 	
 	@Override
 	protected boolean doTransferStack(ItemStack stack, int slot) {
-		if((slot < 9 || slot >= 13) && stack.getItem() == IntegratedCircuits.itemLaser) {
+		if(slot >= 13 && stack.getItem() == IntegratedCircuits.itemLaser) {
+			//Transfer lasers to laser slots
 			if(!mergeItemStack(stack, 9, 13, false))
 				return false;
 		} else if(slot < 13) {
+			//Transfer from machine to player
 			if(!mergeItemStack(stack, 13, inventorySlots.size(), false))
 				return false;
 		} else {
-			if(!mergeItemStack(stack, 1, 9, false))
-				return false;
+			//Transfer materials from player to machine
+			if(!mergeItemStack(stack, 1, 9, false)) {
+				if(slot < 40) {
+					//Transfer from inventoy into hotbar
+					if(!mergeItemStack(stack, 40, 49, false))
+						return false;
+					//Transfer from hotbar into inventory
+				} else if(!mergeItemStack(stack, 13, 40, false))
+					return false;
+			}
 		}
 		return true;
 	}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerBase.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerBase.java
@@ -47,6 +47,72 @@ public abstract class ContainerBase extends Container {
 	}
 	
 	/**
+	 * Gets the current amount that is available of an item type, crawls the
+	 * custom inventory
+	 **/
+	public int getAmountOf(Item item) {
+		int amount = 0;
+		for (int i = 0; i < 7; i++) {
+			Slot s = getSlot(i + 2);
+			if (s.getHasStack() && s.getStack().getItem() == item)
+				amount += s.getStack().stackSize;
+		}
+		return amount;
+	}
+	
+	@Override
+	protected boolean mergeItemStack(ItemStack stack, int begin, int end, boolean reverse) {
+		boolean changed = false;
+		if (stack.isStackable()) {
+			int i = reverse ? end - 1 : begin;
+			while (i >= begin && i < end && stack.stackSize > 0) {
+				Slot slot = (Slot) inventorySlots.get(i);
+				ItemStack stackInSlot = slot.getStack();
+				if (stackInSlot != null && stackInSlot.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stackInSlot, stack)) {
+					int newSize = stackInSlot.stackSize + stack.stackSize;
+					int maxSize = Math.min(stack.getMaxStackSize(), slot.getSlotStackLimit());
+					if (newSize <= maxSize) {
+						stack.stackSize = 0;
+						stackInSlot.stackSize = newSize;
+						slot.onSlotChanged();
+						changed = true;
+					} else if (stackInSlot.stackSize < maxSize) {
+						stack.stackSize -= maxSize - stackInSlot.stackSize;
+						stackInSlot.stackSize = maxSize;
+						slot.onSlotChanged();
+						changed = true;
+					}
+				}
+				if (reverse)
+					i--;
+				else
+					i++;
+			}
+		}
+		if (stack.stackSize > 0) {
+			int i = reverse ? end - 1 : begin;
+			while (i >= begin && i < end && stack.stackSize > 0) {
+				Slot slot = (Slot) inventorySlots.get(i);
+				if (slot.getStack() == null && slot.isItemValid(stack)) {
+					int maxSize = Math.min(stack.getMaxStackSize(), slot.getSlotStackLimit());
+					ItemStack stackInSlot = stack.copy();
+					stackInSlot.stackSize = Math.min(stack.stackSize, maxSize);
+					stack.stackSize -= stackInSlot.stackSize;
+					slot.putStack(stackInSlot);
+					slot.onSlotChanged();
+					changed = true;
+					break;
+				}
+				if (reverse)
+					i--;
+				else
+					i++;
+			}
+		}
+		return changed;
+	}
+	
+	/**
 	 * Adds the slots for the player inventory to the container at the given coordinates.
 	 */
 	protected void addPlayerInv(IInventory invPlayer, int x, int y) {
@@ -64,17 +130,4 @@ public abstract class ContainerBase extends Container {
 	 */
 	protected abstract boolean doTransferStack(ItemStack stack, int slot);
 	
-	/**
-	 * Gets the current amount that is available of an item type, crawls the
-	 * custom inventory
-	 **/
-	public int getAmountOf(Item item) {
-		int amount = 0;
-		for (int i = 0; i < 7; i++) {
-			Slot s = getSlot(i + 2);
-			if (s.getHasStack() && s.getStack().getItem() == item)
-				amount += s.getStack().stackSize;
-		}
-		return amount;
-	}
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerBase.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerBase.java
@@ -1,0 +1,80 @@
+package moe.nightfall.vic.integratedcircuits;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Base class for GUI containers
+ * 
+ * @author ljfa
+ */
+public abstract class ContainerBase extends Container {
+
+	/**
+	 * Called when a player shift-clicks on a slot. It is called repeatedly
+	 * until it returns null.
+	 * 
+	 * @return null if nothing has happened, e.g. the stack could not be transferred.
+	 * Else, a copy of the stack that was originally in the slot.
+	 */
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer player, int slotInd) {
+		ItemStack copyStack = null;
+		Slot slot = (Slot) inventorySlots.get(slotInd);
+
+		if (slot != null && slot.getHasStack()) {
+			ItemStack stackInSlot = slot.getStack();
+			copyStack = stackInSlot.copy();
+
+			if (!doTransferStack(stackInSlot, slotInd))
+				return null;
+
+			if (stackInSlot.stackSize == 0)
+				slot.putStack(null);
+			else
+				slot.onSlotChanged();
+
+			if (copyStack.stackSize == stackInSlot.stackSize)
+				return null;
+
+			slot.onPickupFromSlot(player, stackInSlot);
+		}
+		return copyStack;
+	}
+	
+	/**
+	 * Adds the slots for the player inventory to the container at the given coordinates.
+	 */
+	protected void addPlayerInv(IInventory invPlayer, int x, int y) {
+		for (int i = 0; i < 3; i++)
+			for (int j = 0; j < 9; j++)
+				addSlotToContainer(new Slot(invPlayer, 9 + j + 9 * i, x + 18 * j, y + 18 * i));
+
+		for (int j = 0; j < 9; j++)
+			addSlotToContainer(new Slot(invPlayer, j, x + 18 * j, y + 58));
+	}
+	
+	/**
+	 * Does the actual transferring of the stack in the slot to somewhere else.
+	 * @return true if the stack could be transferred at least partially
+	 */
+	protected abstract boolean doTransferStack(ItemStack stack, int slot);
+	
+	/**
+	 * Gets the current amount that is available of an item type, crawls the
+	 * custom inventory
+	 **/
+	public int getAmountOf(Item item) {
+		int amount = 0;
+		for (int i = 0; i < 7; i++) {
+			Slot s = getSlot(i + 2);
+			if (s.getHasStack() && s.getStack().getItem() == item)
+				amount += s.getStack().stackSize;
+		}
+		return amount;
+	}
+}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/Gui7Segment.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/Gui7Segment.java
@@ -39,12 +39,18 @@ public class Gui7Segment extends GuiScreen implements IHoverableHandler {
 		guiLeft = (width - xSize) / 2;
 		guiTop = (height - ySize) / 2;
 
-		buttonList
-			.add(cbMaster = (new GuiCheckBoxExt(1, guiLeft + 15, guiTop + 50, I18n
-				.format("gui.integratedcircuits.7segment.master"), false, null, this).setColor(0)
-				.setDropShadow(false)));
-		buttonList.add(cbSlave = (new GuiCheckBoxExt(2, guiLeft + 15, guiTop + 70, I18n
-			.format("gui.integratedcircuits.7segment.slave"), true, null, this).setColor(0).setDropShadow(false)));
+		cbMaster = (new GuiCheckBoxExt(1, guiLeft + 15, guiTop + 50,
+				I18n.format("gui.integratedcircuits.7segment.master"), false, null, this)
+				.setColor(0)
+				.setDropShadow(false));
+		
+		cbSlave = (new GuiCheckBoxExt(2, guiLeft + 15, guiTop + 70,
+				I18n.format("gui.integratedcircuits.7segment.slave"), true, null, this)
+				.setColor(0)
+				.setDropShadow(false));
+		
+		buttonList.add(cbMaster);
+		buttonList.add(cbSlave);
 
 		buttonList.add(dropdown = (new GuiDropdown(0, guiLeft + 45, guiTop + 23, 90, 15, Arrays.asList(
 				I18n.format("gui.integratedcircuits.7segment.mode.simple"),
@@ -86,8 +92,8 @@ public class Gui7Segment extends GuiScreen implements IHoverableHandler {
 			} else
 				dropdown.setEnabled(true);
 		}
-		CommonProxy.networkWrapper.sendToServer(new Packet7SegmentChangeMode(part.getProvider(), dropdown
-			.getSelectedElement(), cbSlave.isChecked()));
+		CommonProxy.networkWrapper.sendToServer(new Packet7SegmentChangeMode(part.getProvider(),
+				dropdown.getSelectedElement(), cbSlave.isChecked()));
 	}
 
 	@Override
@@ -99,8 +105,7 @@ public class Gui7Segment extends GuiScreen implements IHoverableHandler {
 		this.mc.getTextureManager().bindTexture(Resources.RESOURCE_GUI_7SEGMENT_BACKGROUND);
 		drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
 
-		if (!(x >= guiLeft + 119 && x < guiLeft + 119 + 23 && y >= guiTop + 51 && y < guiTop + 51 + 33 && !dropdown
-			.isOpen()))
+		if (!(x >= guiLeft + 119 && x < guiLeft + 119 + 23 && y >= guiTop + 51 && y < guiTop + 51 + 33 && !dropdown.isOpen()))
 			drawTexturedModalRect(guiLeft + 119, guiTop + 51, 150, 0, 23, 33);
 
 		int display = part.digit;

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
@@ -109,7 +109,8 @@ public class Socket implements ISocket {
 
 	@Override
 	public void notifyPartChange() {
-		updateRedstoneIO();
+		if(!provider.getWorld().isRemote)
+			updateRedstoneIO();
 		provider.notifyPartChange();
 	}
 


### PR DESCRIPTION
I extracted a base class for containers. As a result, the ContainerAssembler code is cleaner and shift-clicking stacks works better now.

Also, some minor formatting fixes and a bugfix on FMP gates.