### PR TITLE
Fixes regarding analog redstone IO

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerAssembler.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/ContainerAssembler.java
@@ -32,7 +32,8 @@ public class ContainerAssembler extends ContainerBase {
 		this.addSlotToContainer(new Slot(this.tileentity, 1, 8, 113) {
 			@Override
 			public boolean isItemValid(ItemStack stack) {
-				return stack.getItem() == IntegratedCircuits.itemPCB && stack.getItemDamage() == 0;
+				return stack.getItem() == IntegratedCircuits.itemPCB && stack.getItemDamage() == 0
+						&& tileentity.getStatus() != TileEntityAssembler.RUNNING;
 			}
 
 			@Override

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/compat/BPDevice.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/compat/BPDevice.java
@@ -96,12 +96,14 @@ public class BPDevice implements IBundledDevice, IRedstoneDevice {
 
 	@Override
 	public byte getRedstonePower(ForgeDirection side) {
-		return (byte) (socket.getRedstoneOutput(socket.getSideRel(side.ordinal())) != 0 ? -1 : 0);
+		int out = socket.getRedstoneOutput(socket.getSideRel(side.ordinal()));
+		return (byte) (17 * out); //BluePower uses unsigned byte values from 0 to 255
 	}
 
 	@Override
 	public void setRedstonePower(ForgeDirection side, byte power) {
 		socket.updateInputPre();
+		power = (byte) (Byte.toUnsignedInt(power) / 17);
 		socket.setInput(socket.getSideRel(side.ordinal()), 0, power);
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
@@ -321,11 +321,11 @@ public class Socket implements ISocket {
 	@Override
 	public byte getBundledInput(int side, int frequency) {
 		byte i = input[side][frequency];
-		if(getConnectionTypeAtSide(side) == EnumConnectionType.ANALOG) {
-			if(i <= getRedstoneOutput(side))
+		if (getConnectionTypeAtSide(side) == EnumConnectionType.ANALOG) {
+			if (i <= getRedstoneOutput(side))
 				return 0;
 		} else {
-			if(output[side][frequency] != 0)
+			if (output[side][frequency] != 0)
 				return 0;
 		}
 		return i;
@@ -336,13 +336,12 @@ public class Socket implements ISocket {
 		EnumConnectionType conType = getConnectionTypeAtSide(side);
 		if (conType == EnumConnectionType.ANALOG) {
 			// Convert digital to analog, take highest output
-			byte a = 0;
 			byte[] out = getOutput()[side];
-			for (byte i = 0; i < 16; i++) {
+			for (byte i = 15; i >= 0; i--) {
 				if (out[i] != 0)
-					a = i;
+					return i;
 			}
-			return a;
+			return 0;
 		} else if (conType == EnumConnectionType.SIMPLE) {
 			return getBundledOutput(side, 0);
 		}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/gate/Socket.java
@@ -318,17 +318,17 @@ public class Socket implements ISocket {
 		return getBundledInput(side, 0);
 	}
 
-	// TODO Give the higher one the precedence in case of analog, see
-	// https://github.com/Victorious3/Integrated-Circuits/issues/50
-
 	@Override
 	public byte getBundledInput(int side, int frequency) {
-		if (getConnectionTypeAtSide(side) == EnumConnectionType.ANALOG) {
-			if (getRedstoneOutput(side) != 0)
+		byte i = input[side][frequency];
+		if(getConnectionTypeAtSide(side) == EnumConnectionType.ANALOG) {
+			if(i <= getRedstoneOutput(side))
+				return 0;
+		} else {
+			if(output[side][frequency] != 0)
 				return 0;
 		}
-		byte i = input[side][frequency];
-		return output[side][frequency] > 0 ? 0 : i;
+		return i;
 	}
 
 	@Override


### PR DESCRIPTION
Analog inputs to a side will now take precedence before output if they are stronger. This behaviour is more intuitive and seems to function just as well as the previous variant.
Also, analog input and output to BluePower wires is now working properly.
Bundled output is working as well without flickering.

Also, a small fix to the Assembler container to make sure it doesn't void PCBs.