### PR TITLE
Remove dependency from Java 8 libraries

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/compat/BPDevice.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/compat/BPDevice.java
@@ -103,7 +103,7 @@ public class BPDevice implements IBundledDevice, IRedstoneDevice {
 	@Override
 	public void setRedstonePower(ForgeDirection side, byte power) {
 		socket.updateInputPre();
-		power = (byte) (Byte.toUnsignedInt(power) / 17);
+		power = (byte) ((power & 0xFF) / 17); //Convert signed byte to unsigned int
 		socket.setInput(socket.getSideRel(side.ordinal()), 0, power);
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/gate/GatePeripheral.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/gate/GatePeripheral.java
@@ -55,12 +55,13 @@ public abstract class GatePeripheral implements IPeripheral {
 			if (m == null) {
 				return null;
 			}
-			if (arguments.length != m.getParameterCount()) {
+			Class<?>[] paramTypes = m.getParameterTypes();
+			if (arguments.length != paramTypes.length) {
 				throw new LuaException("Illegal amount of parameters!");
 			}
-			for (int i = 0; i < m.getParameterTypes().length; i++) {
-				if (!m.getParameterTypes()[i].isAssignableFrom(arguments[i].getClass()))
-					throw new LuaException("Illegal parameter at index " + i + ". Expected '" + m.getParameterTypes()[i] + "', got '" + arguments[i].getClass() + "'.");
+			for (int i = 0; i < paramTypes.length; i++) {
+				if (!paramTypes[i].isAssignableFrom(arguments[i].getClass()))
+					throw new LuaException("Illegal parameter at index " + i + ". Expected '" + paramTypes[i] + "', got '" + arguments[i].getClass() + "'.");
 			}
 			Object o = m.invoke(this, arguments);
 			if (o == null) {

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/gate/GateRegistry.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/gate/GateRegistry.java
@@ -105,7 +105,9 @@ public class GateRegistry implements IGateRegistry {
 			IntegratedCircuits.logger.fatal("Tried to register gate provider instance after initialization phase: "
 					+ Loader.instance().activeModContainer());
 		}
-		List<GateIOProvider> list = ioProviderRegistry.getOrDefault(clazz, new LinkedList());
+		List<GateIOProvider> list = ioProviderRegistry.get(clazz);
+		if(list == null)
+			list = new LinkedList<GateIOProvider>();
 		list.add(provider);
 		ioProviderRegistry.put(clazz, list);
 	}
@@ -141,7 +143,9 @@ public class GateRegistry implements IGateRegistry {
 	private Pair<ProxyFactory, ProxyCache> createProxyFactory(Class<?> clazz) {
 		try {
 			IntegratedCircuits.logger.info("Creating proxy class for " + clazz);
-			List<GateIOProvider> list = ioProviderRegistry.getOrDefault(clazz, new LinkedList());
+			List<GateIOProvider> list = ioProviderRegistry.get(clazz);
+			if(list == null)
+				list = new LinkedList<GateIOProvider>();
 			ProxyFactory pf = new ProxyFactory();
 			pf.setSuperclass(clazz);
 			HashSet<Class> proxyInterfaces = Sets.newHashSet();


### PR DESCRIPTION
Some machnies (e.g. copygirl's server) are still running Java 7. Seeing that not much new functions from Java 8 are used, it might make sense to get rid of them.
Although unfortunately that makes the code slightly longer.