### PR TITLE
CAD GUI rework

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/asm/GPInjectorTransformer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/asm/GPInjectorTransformer.java
@@ -68,7 +68,7 @@ public class GPInjectorTransformer implements IClassTransformer, Opcodes {
 
 				// add parameters
 				Class<?>[] parameters = m.getParameterTypes();
-				for (int i = 0; i < m.getParameterCount(); i++) {
+				for (int i = 0; i < parameters.length; i++) {
 					mv.visitVarInsn(Type.getType(parameters[i]).getOpcode(ILOAD), i + 1);
 				}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -461,9 +461,9 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		GL11.glEnable(GL11.GL_TEXTURE_2D);
 	}
 
-	private void cadCursor(double mouseX, double mouseY, CircuitData data, int w, int left, int top, int right, int bottom) {
+	private void renderCadCursor(double mouseX, double mouseY, CircuitData data, int size) {
 		Tessellator tes = Tessellator.instance;
-		if (mouseX > 0 && mouseY > 0 && mouseX < w - 1 && mouseY < w - 1 && !isShiftKeyDown() && !blockMouseInput) {
+		if (mouseX > 0 && mouseY > 0 && mouseX < size - 1 && mouseY < size - 1 && !isShiftKeyDown() && !blockMouseInput) {
 			int gridX = (int) mouseX;
 			int gridY = (int) mouseY;
 			if (!drag && selectedPart != null) {
@@ -509,58 +509,61 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 							GL11.glColor3f(0F, 0.4F, 0F);
 							break;
 					}
-					
-					gridX = startX;
-					gridY = startY;
-
-					tes.startDrawingQuads();
-					CircuitPartRenderer.addQuad(gridX, gridY, 0, 0, 1, 1, 1, 1, 16, 16, 0);
-					if (endY > startY)
-						CircuitPartRenderer.addQuad(gridX, gridY, 4, 0, 1, 1, 1, 1, 16, 16, 0);
-					else if (endY < startY)
-						CircuitPartRenderer.addQuad(gridX, gridY, 2, 0, 1, 1, 1, 1, 16, 16, 0);
-					else if (endX > startX)
-						CircuitPartRenderer.addQuad(gridX, gridY, 3, 0, 1, 1, 1, 1, 16, 16, 0);
-					else if (endX < startX)
-						CircuitPartRenderer.addQuad(gridX, gridY, 1, 0, 1, 1, 1, 1, 16, 16, 0);
-
-					while (gridX != endX || gridY != endY) {
-						if (gridY < endY)
-							gridY++;
-						else if (gridY > endY)
-							gridY--;
-						else if (gridX < endX)
-							gridX++;
-						else if (gridX > endX)
-							gridX--;
-
-						if (gridY != endY)
-							CircuitPartRenderer.addQuad(gridX, gridY, 6, 0, 1, 1, 1, 1, 16, 16, 0);
-						else if (gridY == endY && gridX == startX) {
-							CircuitPartRenderer.addQuad(gridX, gridY, 0, 0, 1, 1, 1, 1, 16, 16, 0);
-							if (endY > startY)
-								CircuitPartRenderer.addQuad(gridX, gridY, 2, 0, 1, 1, 1, 1, 16, 16, 0);
-							else if (endY < startY)
-								CircuitPartRenderer.addQuad(gridX, gridY, 4, 0, 1, 1, 1, 1, 16, 16, 0);
-							if (endX > startX)
-								CircuitPartRenderer.addQuad(gridX, gridY, 3, 0, 1, 1, 1, 1, 16, 16, 0);
-							else if (endX < startX)
-								CircuitPartRenderer.addQuad(gridX, gridY, 1, 0, 1, 1, 1, 1, 16, 16, 0);
-						} else if (gridX != endX)
-							CircuitPartRenderer.addQuad(gridX, gridY, 5, 0, 1, 1, 1, 1, 16, 16, 0);
-						else if (gridX == endX) {
-							CircuitPartRenderer.addQuad(gridX, gridY, 0, 0, 1, 1, 1, 1, 16, 16, 0);
-							if (endX > startX)
-								CircuitPartRenderer.addQuad(gridX, gridY, 1, 0, 1, 1, 1, 1, 16, 16, 0);
-							else if (endX < startX)
-								CircuitPartRenderer.addQuad(gridX, gridY, 3, 0, 1, 1, 1, 1, 16, 16, 0);
-						}
-					}
-					tes.draw();
+					renderDraggedWire();
 					GL11.glColor3f(1, 1, 1);
 				}
 			}
 		}
+	}
+	
+	private void renderDraggedWire() {
+		int x = startX;
+		int y = startY;
+
+		Tessellator.instance.startDrawingQuads();
+		CircuitPartRenderer.addQuad(x, y, 0, 0, 1, 1, 1, 1, 16, 16, 0);
+		if (endY > startY)
+			CircuitPartRenderer.addQuad(x, y, 4, 0, 1, 1, 1, 1, 16, 16, 0);
+		else if (endY < startY)
+			CircuitPartRenderer.addQuad(x, y, 2, 0, 1, 1, 1, 1, 16, 16, 0);
+		else if (endX > startX)
+			CircuitPartRenderer.addQuad(x, y, 3, 0, 1, 1, 1, 1, 16, 16, 0);
+		else if (endX < startX)
+			CircuitPartRenderer.addQuad(x, y, 1, 0, 1, 1, 1, 1, 16, 16, 0);
+
+		while (x != endX || y != endY) {
+			if (y < endY)
+				y++;
+			else if (y > endY)
+				y--;
+			else if (x < endX)
+				x++;
+			else if (x > endX)
+				x--;
+
+			if (y != endY)
+				CircuitPartRenderer.addQuad(x, y, 6, 0, 1, 1, 1, 1, 16, 16, 0);
+			else if (y == endY && x == startX) {
+				CircuitPartRenderer.addQuad(x, y, 0, 0, 1, 1, 1, 1, 16, 16, 0);
+				if (endY > startY)
+					CircuitPartRenderer.addQuad(x, y, 2, 0, 1, 1, 1, 1, 16, 16, 0);
+				else if (endY < startY)
+					CircuitPartRenderer.addQuad(x, y, 4, 0, 1, 1, 1, 1, 16, 16, 0);
+				if (endX > startX)
+					CircuitPartRenderer.addQuad(x, y, 3, 0, 1, 1, 1, 1, 16, 16, 0);
+				else if (endX < startX)
+					CircuitPartRenderer.addQuad(x, y, 1, 0, 1, 1, 1, 1, 16, 16, 0);
+			} else if (x != endX)
+				CircuitPartRenderer.addQuad(x, y, 5, 0, 1, 1, 1, 1, 16, 16, 0);
+			else if (x == endX) {
+				CircuitPartRenderer.addQuad(x, y, 0, 0, 1, 1, 1, 1, 16, 16, 0);
+				if (endX > startX)
+					CircuitPartRenderer.addQuad(x, y, 1, 0, 1, 1, 1, 1, 16, 16, 0);
+				else if (endX < startX)
+					CircuitPartRenderer.addQuad(x, y, 3, 0, 1, 1, 1, 1, 16, 16, 0);
+			}
+		}
+		Tessellator.instance.draw();
 	}
 
 	private void mouseDrag(int x, int y, int left, int top, int right, int bottom) {
@@ -602,7 +605,7 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 		if(!isShiftKeyDown())
 			renderTunnelConnections(data, isCtrlKeyDown());
-		cadCursor(mouseX, mouseY, data, data.getSize(), editorLeft, editorTop, editorRight, editorBottom);
+		renderCadCursor(mouseX, mouseY, data, data.getSize());
 		GL11.glDisable(GL11.GL_BLEND);
 
 		GL11.glPopMatrix();

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -226,26 +226,26 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	
 	//Functions to convert between screen coordinates and circuit board coordinates
 	private double boardAbs2RelX(double absX) {
-		return (absX - (editorLeft + xSizeEditor/2 + tileentity.offX)) / getScaleFactor() + getBoardSize()/2;
+		return (absX - (editorLeft + xSizeEditor/2 + tileentity.offX)) / getScaleFactor() + getBoardSize()/2.0;
 	}
 	
 	private double boardAbs2RelY(double absY) {
-		return (absY - (editorTop + ySizeEditor/2 + tileentity.offY)) / getScaleFactor() + getBoardSize()/2;
+		return (absY - (editorTop + ySizeEditor/2 + tileentity.offY)) / getScaleFactor() + getBoardSize()/2.0;
 	}
 	
 	private double boardRel2AbsX(double relX) {
-		return (relX - getBoardSize()/2) * getScaleFactor() + (editorLeft + xSizeEditor/2 + tileentity.offX);
+		return (relX - getBoardSize()/2.0) * getScaleFactor() + (editorLeft + xSizeEditor/2.0 + tileentity.offX);
 	}
 	
 	private double boardRel2AbsY(double relY) {
-		return (relY - getBoardSize()/2) * getScaleFactor() + (editorTop + ySizeEditor/2 + tileentity.offY);
+		return (relY - getBoardSize()/2.0) * getScaleFactor() + (editorTop + ySizeEditor/2.0 + tileentity.offY);
 	}
 	
 	private float getScaleFactor() {
 		return SCALE * tileentity.scale;
 	}
 	
-	private double getBoardSize() {
+	private int getBoardSize() {
 		return tileentity.getCircuitData().getSize();
 	}
 	
@@ -281,7 +281,7 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	}
 
 	private static int getOffsetCentre(int topOffset, int bottomOffset, int fullLength, int thingLength) {
-		return ((topOffset + fullLength - bottomOffset) / 2) - (thingLength / 2);
+		return (topOffset + fullLength - bottomOffset - thingLength) / 2;
 	}
 
 	public void refreshIO() {
@@ -408,9 +408,9 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		
 		GL11.glPushMatrix();
 		//Scale and translate to the center of the screen
-		GL11.glTranslated(editorLeft + xSizeEditor/2 + tileentity.offX, editorTop + ySizeEditor/2 + tileentity.offY, 0);
+		GL11.glTranslated(editorLeft + xSizeEditor/2.0 + tileentity.offX, editorTop + ySizeEditor/2.0 + tileentity.offY, 0);
 		GL11.glScalef(getScaleFactor(), getScaleFactor(), 1F);
-		GL11.glTranslated(-getBoardSize()/2, -getBoardSize()/2, 0);
+		GL11.glTranslated(-getBoardSize()/2.0, -getBoardSize()/2.0, 0);
 
 		//Render the circuit board
 		CircuitPartRenderer.renderPerfboard(data);

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -260,19 +260,6 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		return ((topOffset + fullLength - bottomOffset) / 2) - (thingLength / 2);
 	}
 
-	/** Debugging tool, used to help with positioning. **/
-	private void guiInfo() {
-		System.out.println();
-		System.out.println("GUI Info");
-		System.out.println("this.width = " + this.width + "; this.height = " + this.height + ";");
-		System.out.println("this.xSize = " + this.xSize + "; this.ySize = " + this.ySize + ";");
-		System.out.println("this.guiLeft = " + this.guiLeft + "; this.guiTop = " + this.guiTop + ";");
-		System.out.println("this.guiRight = " + this.guiRight + "; this.guiBottom = " + this.guiBottom + ";");
-		System.out.println("this.xSizeEditor = " + this.xSizeEditor + "; this.ySizeEditor = " + this.ySizeEditor + ";");
-		System.out.println("this.editorLeft = " + this.editorLeft + "; this.editorTop = " + this.editorTop + ";");
-		System.out.println("this.editorRight = " + this.editorRight + "; this.editorBottom = " + this.editorBottom + ";");
-	}
-
 	public void refreshIO() {
 		checkN.refresh();
 		checkE.refresh();
@@ -381,64 +368,27 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		// Draw the "border"
 		drawHollowRect(guiLeft, guiTop, guiRight, guiBottom, editorLeft, editorTop, editorRight, editorBottom, 0xAA3A404A);
 
-
 		CircuitData data = tileentity.getCircuitData();
 
 		int w = data.getSize();
 
 		mouseDrag(x, y, w, editorLeft, editorTop, editorRight, editorBottom);
 
-
 		// Draw the name of the CAD
 		fontRendererObj.drawString(I18n.format("gui.integratedcircuits.cad.name"), guiLeft + 45, guiTop + 12, 0xFFFFFF);
 
-		GL11.glPushMatrix();
-		GL11.glTranslated(guiLeft, guiTop, 0);
 		mc.getTextureManager().bindTexture(Resources.RESOURCE_PCB);
 
 		// Render the "board"
 		GL11.glEnable(GL11.GL_SCISSOR_TEST);
-		GL11.glScissor((int) ((editorLeft) * guiScale),
-			this.mc.displayHeight - (int) ((editorTop) * guiScale) - ySizeEditor * guiScale,
-			(int) (xSizeEditor * guiScale),
-			(int) (ySizeEditor * guiScale));
+		GL11.glScissor(editorLeft * guiScale, this.mc.displayHeight - editorBottom * guiScale,
+				xSizeEditor * guiScale, ySizeEditor * guiScale);
+		
+		GL11.glPushMatrix();
+		GL11.glTranslated(guiLeft, guiTop, 0);
 		GL11.glScalef(tileentity.scale, tileentity.scale, 1F);
 
-		CircuitPartRenderer.renderPerfboard(getRelativeOffX(), getRelativeOffY(), data);
-		CircuitPartRenderer.renderParts(tileentity, getRelativeOffX(), getRelativeOffY());
-
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
-		GL11.glDisable(GL11.GL_TEXTURE_2D);
-		GL11.glColor4f(1F, 1F, 1F, 1F);
-
-
-		boolean ctrl = isCtrlKeyDown();
-
-		// Render connections for tunnels
-		if (!isShiftKeyDown()) {
-			tessellator.startDrawingQuads();
-			for (int x3 = 0; x3 < data.getSize(); x3++) {
-				for (int y3 = 0; y3 < data.getSize(); y3++) {
-					if (x3 == endX && y3 == endY && data.getPart(new Vec2(x3, y3)) instanceof PartTunnel && selectedPart == null) {
-						drawTunnelConnection(x3, y3);
-					}
-					if (drag && selectedPart == null) {
-						Tessellator.instance.setColorRGBA_F(0F, 0F, 1F, 1F);
-						CircuitPartRenderer.addQuad(startX * 16 + getRelativeOffX(), startY * 16 + getRelativeOffY(), 0, 0, 16, 16);
-					}
-					if (ctrl) {
-						drawTunnelConnection(x3, y3);
-					}
-				}
-			}
-			tessellator.draw();
-		}
-
-		GL11.glEnable(GL11.GL_TEXTURE_2D);
-		GL11.glColor4f(0.6F, 0.6F, 0.6F, 0.7F);
-
-		cadCursor(x, y, tessellator, mouseX, mouseY, data, w, editorLeft, editorTop, editorRight, editorBottom);
+		//Rendering of the board goes here
 
 		GL11.glDisable(GL11.GL_SCISSOR_TEST);
 		GL11.glPopMatrix();

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -230,19 +230,19 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	
 	//Functions to convert between screen coordinates and circuit board coordinates
 	private double boardAbs2RelX(double absX) {
-		return (absX - (editorLeft + xSizeEditor/2 + tileentity.offX)) / getScaleFactor() + getBoardSize()/2.0;
+		return (absX - getAbsBoardOffsetX()) / getScaleFactor() + getBoardSize()/2.0;
 	}
 	
 	private double boardAbs2RelY(double absY) {
-		return (absY - (editorTop + ySizeEditor/2 + tileentity.offY)) / getScaleFactor() + getBoardSize()/2.0;
+		return (absY - getAbsBoardOffsetY()) / getScaleFactor() + getBoardSize()/2.0;
 	}
 	
 	private double boardRel2AbsX(double relX) {
-		return (relX - getBoardSize()/2.0) * getScaleFactor() + (editorLeft + xSizeEditor/2.0 + tileentity.offX);
+		return (relX - getBoardSize()/2.0) * getScaleFactor() + getAbsBoardOffsetX();
 	}
 	
 	private double boardRel2AbsY(double relY) {
-		return (relY - getBoardSize()/2.0) * getScaleFactor() + (editorTop + ySizeEditor/2.0 + tileentity.offY);
+		return (relY - getBoardSize()/2.0) * getScaleFactor() + getAbsBoardOffsetY();
 	}
 	
 	private float getScaleFactor() {
@@ -255,6 +255,14 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	
 	private double getAbsBoardSize() {
 		return getScaleFactor() * getBoardSize();
+	}
+	
+	private double getAbsBoardOffsetX() {
+		return editorLeft + xSizeEditor/2.0 + tileentity.offX;
+	}
+	
+	private double getAbsBoardOffsetY() {
+		return editorTop + ySizeEditor/2.0 + tileentity.offY;
 	}
 	
 	private double getBoardLeft() {
@@ -323,7 +331,6 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		// Draw the name of the CAD
 		fontRendererObj.drawString(I18n.format("gui.integratedcircuits.cad.name"), guiLeft + 45, guiTop + 12, 0xFFFFFF);
 
-		mc.getTextureManager().bindTexture(Resources.RESOURCE_PCB);
 		renderCircuitBoard(relX, relY, guiScale);
 		//Draw inner gradient
 		drawGradients(editorLeft, editorTop, editorRight, editorBottom, 4);
@@ -426,7 +433,7 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		
 		GL11.glPushMatrix();
 		//Scale and translate to the center of the screen
-		GL11.glTranslated(editorLeft + xSizeEditor/2.0 + tileentity.offX, editorTop + ySizeEditor/2.0 + tileentity.offY, 0);
+		GL11.glTranslated(getAbsBoardOffsetX(), getAbsBoardOffsetY(), 0);
 		GL11.glScalef(getScaleFactor(), getScaleFactor(), 1F);
 		GL11.glTranslated(-getBoardSize()/2.0, -getBoardSize()/2.0, 0);
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -85,6 +85,8 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	// Used by the wires
 	private int startX, startY, endX, endY;
 	private boolean drag;
+	
+	private static final float SCALE = 16f; 
 
 	// Callbacks
 	private GuiCallback<GuiPCBLayout> callbackDelete;
@@ -220,29 +222,29 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		refreshUI();
 	}
 	
-	private double getCircuitSize() {
+	private double getBoardSize() {
 		return tileentity.getCircuitData().getSize();
 	}
 	
-	private double getBoardSize() {
-		return CircuitPartRenderer.PART_SIZE * getCircuitSize();
+	//Functions to convert between screen coordinates and circuit board coordinates
+	private float getScaleFactor() {
+		return SCALE * tileentity.scale;
 	}
 	
-	//Functions to convert between screen coordinates and circuit board coordinates
 	private double boardAbs2RelX(double absX) {
-		return (absX - (editorLeft + xSizeEditor/2 + tileentity.offX)) / tileentity.scale + getBoardSize()/2;
+		return (absX - (editorLeft + xSizeEditor/2 + tileentity.offX)) / getScaleFactor() + getBoardSize()/2;
 	}
 	
 	private double boardAbs2RelY(double absY) {
-		return (absY - (editorTop + ySizeEditor/2 + tileentity.offY)) / tileentity.scale + getBoardSize()/2;
+		return (absY - (editorTop + ySizeEditor/2 + tileentity.offY)) / getScaleFactor() + getBoardSize()/2;
 	}
 	
 	private double boardRel2AbsX(double relX) {
-		return (relX - getBoardSize()/2) * tileentity.scale + (editorLeft + xSizeEditor/2 + tileentity.offX);
+		return (relX - getBoardSize()/2) * getScaleFactor() + (editorLeft + xSizeEditor/2 + tileentity.offX);
 	}
 	
 	private double boardRel2AbsY(double relY) {
-		return (relY - getBoardSize()/2) * tileentity.scale + (editorTop + ySizeEditor/2 + tileentity.offY);
+		return (relY - getBoardSize()/2) * getScaleFactor() + (editorTop + ySizeEditor/2 + tileentity.offY);
 	}
 	
 	private double getBoardLeft() {
@@ -403,7 +405,7 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		GL11.glPushMatrix();
 		//Scale and translate to the center of the screen
 		GL11.glTranslated(editorLeft + xSizeEditor/2 + tileentity.offX, editorTop + ySizeEditor/2 + tileentity.offY, 0);
-		GL11.glScalef(tileentity.scale, tileentity.scale, 1F);
+		GL11.glScalef(getScaleFactor(), getScaleFactor(), 1F);
 		GL11.glTranslated(-getBoardSize()/2, -getBoardSize()/2, 0);
 
 		//Render the circuit board

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/GuiPCBLayout.java
@@ -756,27 +756,29 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 	}
 
 	private void scale(int i) {
-		int w = tileentity.getCircuitData().getSize();
-
-		double ow = w * 16 * tileentity.scale;
-		float oldScale = tileentity.scale;
-
 		int index = scales.indexOf(tileentity.scale);
 
 		if (i > 0 && index + 1 < scales.size())
-			tileentity.scale = scales.get(index + 1);
+			scaleAround(0, 0, tileentity.scale, scales.get(index + 1));
 		if (i < 0 && index - 1 >= 0)
-			tileentity.scale = scales.get(index - 1);
+			scaleAround(0, 0, tileentity.scale, scales.get(index - 1));
 
 		if (i != 0) {
 			buttonMinus.enabled = true;
 			buttonPlus.enabled = true;
 
-			if (tileentity.scale == 0.17F)
+			if (tileentity.scale == scales.get(0))
 				buttonMinus.enabled = false;
-			if (tileentity.scale == 2F)
+			if (tileentity.scale == scales.get(scales.size()-1))
 				buttonPlus.enabled = false;
 		}
+	}
+	
+	private void scaleAround(double centerX, double centerY, float from, float to) {
+		tileentity.scale = to;
+		double factor = to / from;
+		tileentity.offX = centerX + factor * (tileentity.offX - centerX); 
+		tileentity.offY = centerY + factor * (tileentity.offY - centerY); 
 	}
 
 	@Override
@@ -786,7 +788,7 @@ public class GuiPCBLayout extends GuiContainer implements IGuiCallback, IHoverab
 		super.handleMouseInput();
 	}
 
-	private static List<Float> scales = Arrays.asList(0.17F, 0.2F, 0.25F, 0.33F, 0.5F, 0.67F, 1F, 1.5F, 2F);
+	private static final List<Float> scales = Arrays.asList(0.17F, 0.2F, 0.25F, 0.33F, 0.5F, 0.67F, 1F, 1.5F, 2F);
 
 	@Override
 	protected void mouseMovedOrUp(int x, int y, int button) {

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
@@ -1,7 +1,5 @@
 package moe.nightfall.vic.integratedcircuits.cp;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import moe.nightfall.vic.integratedcircuits.client.Resources;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartCPGate;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartIOBit;
@@ -15,9 +13,14 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 @SideOnly(Side.CLIENT)
 public class CircuitPartRenderer {
 
+	public static final int PART_SIZE = 16;
+	
 	public enum EnumRenderType {
 		GUI, WORLD, WORLD_16x
 	}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
@@ -1,5 +1,7 @@
 package moe.nightfall.vic.integratedcircuits.cp;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import moe.nightfall.vic.integratedcircuits.client.Resources;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartCPGate;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartIOBit;
@@ -12,9 +14,6 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class CircuitPartRenderer {
@@ -139,6 +138,8 @@ public class CircuitPartRenderer {
 		int w = circuit.getCircuitData().getSize();
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB);
+		GL11.glPushMatrix();
+		GL11.glScalef(1F / PART_SIZE, 1F / PART_SIZE, 1F / PART_SIZE);
 		tes.startDrawingQuads();
 		for (int x2 = 0; x2 < w; x2++) {
 			for (int y2 = 0; y2 < w; y2++) {
@@ -147,6 +148,7 @@ public class CircuitPartRenderer {
 			}
 		}
 		tes.draw();
+		GL11.glPopMatrix();
 	}
 
 	public static void renderParts(ICircuit circuit, double offX, double offY, boolean[][] exc, EnumRenderType type) {
@@ -174,16 +176,16 @@ public class CircuitPartRenderer {
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB_PERF1);
 		tes.startDrawingQuads();
 		tes.setColorRGBA_F(1F, 1F, 1F, 1F);
-		addQuad(0, 0, 0, 0, size * 16, size * 16, 16, 16, 16D / size, 16D / size, 0);
+		addQuad(0, 0, 0, 0, size, size, 16, 16, 16D / size, 16D / size, 0);
 		tes.draw();
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB_PERF2);
 		tes.startDrawingQuads();
 		tes.setColorRGBA_F(1F, 1F, 1F, 1F);
-		addQuad(0, 0, 0, 0, 16, size * 16, 16, 16, 16D, 16D / size, 0);
-		addQuad(size * 16 - 16, 0, 0, 0, 16, size * 16, 16, 16, 16, 16D / size, 0);
-		addQuad(0, 0, 0, 0, size * 16, 16, 16, 16, 16D / size, 16, 0);
-		addQuad(0, data.getSize() * 16 - 16, 0, 0, size * 16, 16, 16, 16, 16D / size, 16, 0);
+		addQuad(0, 0, 0, 0, 1, size, 16, 16, 16D, 16D / size, 0);
+		addQuad(size - 1, 0, 0, 0, 1, size, 16, 16, 16, 16D / size, 0);
+		addQuad(0, 0, 0, 0, size, 1, 16, 16, 16D / size, 16, 0);
+		addQuad(0, size - 1, 0, 0, size, 1, 16, 16, 16D / size, 16, 0);
 		tes.draw();
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
@@ -131,11 +131,10 @@ public class CircuitPartRenderer {
 		}
 	}
 
-	public static void renderParts(ICircuit circuit, double offX, double offY) {
+	public static void renderParts(ICircuit circuit) {
 		Tessellator tes = Tessellator.instance;
 		int w = circuit.getCircuitData().getSize();
 
-		GL11.glTranslated(offX, offY, 0);
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB);
 		tes.startDrawingQuads();
 		for (int x2 = 0; x2 < w; x2++) {
@@ -145,7 +144,6 @@ public class CircuitPartRenderer {
 			}
 		}
 		tes.draw();
-		GL11.glTranslated(-offX, -offY, 0);
 	}
 
 	public static void renderParts(ICircuit circuit, double offX, double offY, boolean[][] exc, EnumRenderType type) {
@@ -166,27 +164,24 @@ public class CircuitPartRenderer {
 		GL11.glTranslated(-offX, -offY, 0);
 	}
 
-	public static void renderPerfboard(double offX, double offY, CircuitData data) {
+	public static void renderPerfboard(CircuitData data) {
 		Tessellator tes = Tessellator.instance;
-		int w = data.getSize();
+		int size = data.getSize();
 
-		GL11.glTranslated(offX, offY, 0);
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB_PERF1);
 		tes.startDrawingQuads();
 		tes.setColorRGBA_F(1F, 1F, 1F, 1F);
-		addQuad(0, 0, 0, 0, data.getSize() * 16, data.getSize() * 16, 16, 16, 16D / data.getSize(),
-				16D / data.getSize(), 0);
+		addQuad(0, 0, 0, 0, size * 16, size * 16, 16, 16, 16D / size, 16D / size, 0);
 		tes.draw();
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB_PERF2);
 		tes.startDrawingQuads();
 		tes.setColorRGBA_F(1F, 1F, 1F, 1F);
-		addQuad(0, 0, 0, 0, 16, data.getSize() * 16, 16, 16, 16D, 16D / data.getSize(), 0);
-		addQuad(data.getSize() * 16 - 16, 0, 0, 0, 16, data.getSize() * 16, 16, 16, 16, 16D / data.getSize(), 0);
-		addQuad(0, 0, 0, 0, data.getSize() * 16, 16, 16, 16, 16D / data.getSize(), 16, 0);
-		addQuad(0, data.getSize() * 16 - 16, 0, 0, data.getSize() * 16, 16, 16, 16, 16D / data.getSize(), 16, 0);
+		addQuad(0, 0, 0, 0, 16, size * 16, 16, 16, 16D, 16D / size, 0);
+		addQuad(size * 16 - 16, 0, 0, 0, 16, size * 16, 16, 16, 16, 16D / size, 0);
+		addQuad(0, 0, 0, 0, size * 16, 16, 16, 16, 16D / size, 16, 0);
+		addQuad(0, data.getSize() * 16 - 16, 0, 0, size * 16, 16, 16, 16, 16D / size, 16, 0);
 		tes.draw();
-		GL11.glTranslated(-offX, -offY, 0);
 	}
 
 	public static void renderPartGate(Vec2 pos, ICircuit parent, PartCPGate gate, double x, double y, EnumRenderType type) {

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
@@ -144,7 +144,7 @@ public class CircuitPartRenderer {
 		for (int x2 = 0; x2 < w; x2++) {
 			for (int y2 = 0; y2 < w; y2++) {
 				Vec2 pos = new Vec2(x2, y2);
-				renderPartPayload(pos, circuit, circuit.getCircuitData().getPart(pos), x2 * 16, y2 * 16, EnumRenderType.GUI);
+				renderPartPayload(pos, circuit, circuit.getCircuitData().getPart(pos), x2 * PART_SIZE, y2 * PART_SIZE, EnumRenderType.GUI);
 			}
 		}
 		tes.draw();

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPartRenderer.java
@@ -37,7 +37,7 @@ public class CircuitPartRenderer {
 	private static void renderPartPayload(Vec2 pos, ICircuit parent, CircuitPart part, double x, double y, EnumRenderType type) {
 		if (type == EnumRenderType.WORLD_16x && !(part instanceof PartNull || part instanceof PartWire || part instanceof PartIOBit)) {
 			Tessellator.instance.setColorRGBA_F(0, 0, 0, 1);
-			addQuad(x, y, 0, 15 * 16, 16, 16);
+			addQuad(x, y, 0, 15 * 16, PART_SIZE, PART_SIZE);
 		}
 
 		part.renderPart(pos, parent, x, y, type);
@@ -139,7 +139,7 @@ public class CircuitPartRenderer {
 
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB);
 		GL11.glPushMatrix();
-		GL11.glScalef(1F / PART_SIZE, 1F / PART_SIZE, 1F / PART_SIZE);
+		GL11.glScalef(1F / PART_SIZE, 1F / PART_SIZE, 1);
 		tes.startDrawingQuads();
 		for (int x2 = 0; x2 < w; x2++) {
 			for (int y2 = 0; y2 < w; y2++) {
@@ -155,18 +155,21 @@ public class CircuitPartRenderer {
 		Tessellator tes = Tessellator.instance;
 		int w = circuit.getCircuitData().getSize();
 
+		GL11.glPushMatrix();
 		GL11.glTranslated(offX, offY, 0);
+		if (type == EnumRenderType.GUI)
+			GL11.glScalef(1F / PART_SIZE, 1F / PART_SIZE, 1);
 		Minecraft.getMinecraft().getTextureManager().bindTexture(Resources.RESOURCE_PCB);
 		tes.startDrawingQuads();
 		for (int x2 = 0; x2 < w; x2++) {
 			for (int y2 = 0; y2 < w; y2++) {
 				Vec2 pos = new Vec2(x2, y2);
 				if (exc[x2][y2])
-					renderPartPayload(pos, circuit, circuit.getCircuitData().getPart(pos), x2 * 16, y2 * 16, type);
+					renderPartPayload(pos, circuit, circuit.getCircuitData().getPart(pos), x2 * PART_SIZE, y2 * PART_SIZE, type);
 			}
 		}
 		tes.draw();
-		GL11.glTranslated(-offX, -offY, 0);
+		GL11.glPopMatrix();
 	}
 
 	public static void renderPerfboard(CircuitData data) {
@@ -199,7 +202,7 @@ public class CircuitPartRenderer {
 				tes.setColorRGBA_F(0F, 1F, 0F, 1F);
 			else
 				tes.setColorRGBA_F(0F, 0.4F, 0F, 1F);
-			addQuad(x, y, 2 * 16, 0, 16, 16);
+			addQuad(x, y, 2 * 16, 0, PART_SIZE, PART_SIZE);
 		}
 
 		if (gate.canConnectToSide(pos, parent, ForgeDirection.SOUTH)) {
@@ -210,7 +213,7 @@ public class CircuitPartRenderer {
 				tes.setColorRGBA_F(0F, 1F, 0F, 1F);
 			else
 				tes.setColorRGBA_F(0F, 0.4F, 0F, 1F);
-			addQuad(x, y, 4 * 16, 0, 16, 16);
+			addQuad(x, y, 4 * 16, 0, PART_SIZE, PART_SIZE);
 		}
 
 		if (gate.canConnectToSide(pos, parent, ForgeDirection.WEST)) {
@@ -221,7 +224,7 @@ public class CircuitPartRenderer {
 				tes.setColorRGBA_F(0F, 1F, 0F, 1F);
 			else
 				tes.setColorRGBA_F(0F, 0.4F, 0F, 1F);
-			addQuad(x, y, 1 * 16, 0, 16, 16);
+			addQuad(x, y, 1 * 16, 0, PART_SIZE, PART_SIZE);
 		}
 
 		if (gate.canConnectToSide(pos, parent, ForgeDirection.EAST)) {
@@ -232,7 +235,7 @@ public class CircuitPartRenderer {
 				tes.setColorRGBA_F(0F, 1F, 0F, 1F);
 			else
 				tes.setColorRGBA_F(0F, 0.4F, 0F, 1F);
-			addQuad(x, y, 3 * 16, 0, 16, 16);
+			addQuad(x, y, 3 * 16, 0, PART_SIZE, PART_SIZE);
 		}
 
 		tes.setColorRGBA_F(0F, 1F, 0F, 1F);
@@ -254,7 +257,7 @@ public class CircuitPartRenderer {
 			tes.setColorRGBA_F(0F, 1F, 0F, 1F);
 		else
 			tes.setColorRGBA_F(0F, 0.4F, 0F, 1F);
-		addQuad(x, y, 0, 2 * 16, 16, 16, rotation);
+		addQuad(x, y, 0, 2 * 16, PART_SIZE, PART_SIZE, rotation);
 
 		if (type == EnumRenderType.GUI
 				&& (cell.getOutputToSide(pos, parent, MiscUtils.rotn(ForgeDirection.EAST, rotation))


### PR DESCRIPTION
(Don't merge yet, it's not quite finished)

I reworked how coordinates on the circuit board are being handled: The circuit board uses relative coordinates from (0,0) to (size, size). The factor of 16 has been dropped: One "cell" now has size 1.
Circuit parts' coordinates are still from (0,0) to (16,16) though.  
There should be less magic numbers now than before,  but I'm going to clean it a bit more. 

Also, the movement of the board is now smooth and when you change the scale,  it scales around the screen's midpoint rather than the board's midpoint. 