### PR TITLE
Allow changing XOR gate inputs

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/Part2I1O.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/Part2I1O.java
@@ -1,0 +1,48 @@
+package moe.nightfall.vic.integratedcircuits.cp.part;
+
+import java.util.ArrayList;
+
+import moe.nightfall.vic.integratedcircuits.cp.ICircuit;
+import moe.nightfall.vic.integratedcircuits.misc.Vec2;
+import moe.nightfall.vic.integratedcircuits.misc.PropertyStitcher.IntProperty;
+import net.minecraft.client.resources.I18n;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public abstract class Part2I1O extends PartSimpleGate {
+	public final IntProperty PROP_CONNECTORS = new IntProperty("CONNECTORS", stitcher, 2);
+
+	@Override
+	public void onClick(Vec2 pos, ICircuit parent, int button, boolean ctrl) {
+		if (button == 0 && ctrl)
+			cycleProperty(pos, parent, PROP_CONNECTORS);
+		super.onClick(pos, parent, button, ctrl);
+	}
+
+	@Override
+	public boolean canConnectToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
+		ForgeDirection s2 = toInternal(pos, parent, side);
+		if (s2 == ForgeDirection.NORTH)
+			return true;
+		int i = getProperty(pos, parent, PROP_CONNECTORS);
+		if (s2 == ForgeDirection.EAST && i == 2)
+			return false;
+		if (s2 == ForgeDirection.SOUTH && i == 0)
+			return false;
+		if (s2 == ForgeDirection.WEST && i == 1)
+			return false;
+		return true;
+	}
+
+	@Override
+	protected boolean hasOutputToSide(Vec2 pos, ICircuit parent, ForgeDirection fd) {
+		return fd == ForgeDirection.NORTH;
+	}
+
+	@Override
+	public ArrayList<String> getInformation(Vec2 pos, ICircuit parent, boolean edit, boolean ctrlDown) {
+		ArrayList<String> text = super.getInformation(pos, parent, edit, ctrlDown);
+		if (edit && ctrlDown)
+			text.add(I18n.format("gui.integratedcircuits.cad.mode"));
+		return text;
+	}
+}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/logic/PartXORGate.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/logic/PartXORGate.java
@@ -4,14 +4,21 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import moe.nightfall.vic.integratedcircuits.cp.CircuitPartRenderer;
 import moe.nightfall.vic.integratedcircuits.cp.ICircuit;
-import moe.nightfall.vic.integratedcircuits.cp.part.PartSimpleGate;
+import moe.nightfall.vic.integratedcircuits.cp.part.Part2I1O;
 import moe.nightfall.vic.integratedcircuits.misc.Vec2;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class PartXORGate extends PartSimpleGate {
+public class PartXORGate extends Part2I1O {
 	@Override
-	public boolean canConnectToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
-		return toInternal(pos, parent, side) != ForgeDirection.SOUTH;
+	public void calcOutput(Vec2 pos, ICircuit parent) {
+		ForgeDirection s3 = toExternal(pos, parent, ForgeDirection.SOUTH);
+		ForgeDirection s4 = toExternal(pos, parent, ForgeDirection.EAST);
+		ForgeDirection s5 = s4.getOpposite();
+
+		// Xor works properly for booleans
+		setOutput(pos, parent, getInputFromSide(pos, parent, s3)
+				^ getInputFromSide(pos, parent, s4)
+				^ getInputFromSide(pos, parent, s5));
 	}
 
 	@Override
@@ -23,14 +30,5 @@ public class PartXORGate extends PartSimpleGate {
 	@Override
 	protected boolean hasOutputToSide(Vec2 pos, ICircuit parent, ForgeDirection fd) {
 		return fd == ForgeDirection.NORTH;
-	}
-
-	@Override
-	protected void calcOutput(Vec2 pos, ICircuit parent) {
-		setOutput(
-				pos,
-				parent,
-				getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.EAST)) != getInputFromSide(pos,
-						parent, toExternal(pos, parent, ForgeDirection.WEST)));
 	}
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/logic/PartXORGate.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/logic/PartXORGate.java
@@ -26,9 +26,4 @@ public class PartXORGate extends Part2I1O {
 	public Vec2 getTextureOffset(Vec2 pos, ICircuit parent, double x, double y, CircuitPartRenderer.EnumRenderType type) {
 		return new Vec2(9, 0);
 	}
-
-	@Override
-	protected boolean hasOutputToSide(Vec2 pos, ICircuit parent, ForgeDirection fd) {
-		return fd == ForgeDirection.NORTH;
-	}
 }


### PR DESCRIPTION
Fixes #99

I copied Part3I1O.java into Part2I1O.java and modified it slightly to disallow enabling all inputs at once.
XOR is now same as OR (code-wise), but with different base class (i.e. 2 inputs only), boolean operation and image, so it definitely works as intended.
Tested it too. In fact, I did this fix for my own IC design that did not fit otherwise :-)
XNOR works without extra changes because it is derived from XOR.