### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/SocketRenderer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/SocketRenderer.java
@@ -147,7 +147,7 @@ public class SocketRenderer extends PartRenderer<ISocket> {
 			if ((stack = player.getCurrentEquippedItem()) != null && stack.getItem() instanceof IGateItem) {
 				MovingObjectPosition mop = Minecraft.getMinecraft().objectMouseOver;
 				BlockCoord pos = socket.getPos();
-				if (mop.typeOfHit == MovingObjectType.BLOCK && mop.blockX == pos.x && mop.blockY == pos.y
+				if (mop != null && mop.typeOfHit == MovingObjectType.BLOCK && mop.blockX == pos.x && mop.blockY == pos.y
 						&& mop.blockZ == pos.z && mop.sideHit == (socket.getSide() ^ 1)) {
 					if (!player.inventory.hasItem(Content.itemSolderingIron)) {
 						if (Config.enableTooltips) {


### PR DESCRIPTION
`Minecraft.getMinecraft().objectMouseOver` reliably returns `null` under certain seemingly random conditions.
I guess nothing is the only meaningful thing to do in such case.
