### PR TITLE
Hopefully fixed #120

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/PartNull.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/PartNull.java
@@ -11,12 +11,8 @@ import static moe.nightfall.vic.integratedcircuits.cp.CircuitPartRenderer.addQua
 
 public class PartNull extends CircuitPart {
 	@Override
-	public void onPlaced(Vec2 pos, ICircuit parent) {
-		for (int i = 2; i < 6; i++) {
-			ForgeDirection fd = ForgeDirection.getOrientation(i);
-			CircuitPart part = getNeighbourOnSide(pos, parent, fd);
-			part.onInputChange(pos.offset(fd), parent, fd.getOpposite());
-		}
+	public boolean canConnectToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/cell/PartANDCell.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/cell/PartANDCell.java
@@ -19,17 +19,18 @@ public class PartANDCell extends PartSimpleGate {
 	@Override
 	public void onInputChange(Vec2 pos, ICircuit parent, ForgeDirection side) {
 		super.onInputChange(pos, parent, side);
-		ForgeDirection fd = toInternal(pos, parent, side);
-		if (fd == ForgeDirection.NORTH || fd == ForgeDirection.SOUTH)
-			getNeighbourOnSide(pos, parent, side.getOpposite()).scheduleInputChange(pos.offset(side.getOpposite()), parent, side);
-		markForUpdate(pos, parent);
+		notifyNeighbours(pos, parent);
 	}
 
 	@Override
 	public boolean getOutputToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
 		ForgeDirection fd = toInternal(pos, parent, side);
-		if (fd == ForgeDirection.NORTH || fd == ForgeDirection.SOUTH)
-			return getInputFromSide(pos, parent, side.getOpposite());
+		// A-la NullCell (only NORTH<=>SOUTH)
+		if ((fd == ForgeDirection.NORTH || fd == ForgeDirection.SOUTH) &&
+				getInputFromSide(pos, parent, side.getOpposite()) && !getInputFromSide(pos, parent, side))
+			return true;
+		
+		// Act as AND gate
 		return super.getOutputToSide(pos, parent, side);
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/cell/PartBufferCell.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/cell/PartBufferCell.java
@@ -17,26 +17,17 @@ public class PartBufferCell extends PartSimpleGate {
 	@Override
 	public void onInputChange(Vec2 pos, ICircuit parent, ForgeDirection side) {
 		super.onInputChange(pos, parent, side);
-		ForgeDirection dir = toInternal(pos, parent, side);
-		getNeighbourOnSide(pos, parent, side.getOpposite()).scheduleInputChange(pos.offset(side.getOpposite()), parent, side);
-		markForUpdate(pos, parent);
+		notifyNeighbours(pos, parent);
 	}
 
 	@Override
 	public boolean getOutputToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
-		ForgeDirection fd = toInternal(pos, parent, side);
-		if (fd == ForgeDirection.EAST)
-			return getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.WEST));
-		else if (fd == ForgeDirection.WEST)
-			return getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.EAST));
-
-		boolean out = super.getOutputToSide(pos, parent, side);
-		if (fd == ForgeDirection.NORTH && !out)
-			return getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.SOUTH));
-		else if (fd == ForgeDirection.SOUTH && !out)
-			return getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.NORTH));
-
-		return out;
+		// A-la NullCell
+		if (getInputFromSide(pos, parent, side.getOpposite()) && !getInputFromSide(pos, parent, side))
+			return true;
+		
+		// But also works as BufferGate
+		return super.getOutputToSide(pos, parent, side);
 	}
 
 	@Override
@@ -56,11 +47,9 @@ public class PartBufferCell extends PartSimpleGate {
 
 	@Override
 	protected void calcOutput(Vec2 pos, ICircuit parent) {
-		setOutput(
-				pos,
-				parent,
-				(getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.EAST)) || getInputFromSide(pos,
-						parent, toExternal(pos, parent, ForgeDirection.WEST))));
+		ForgeDirection east = toExternal(pos, parent, ForgeDirection.EAST);
+		setOutput(pos, parent,
+			getInputFromSide(pos, parent, east) || getInputFromSide(pos, parent, east.getOpposite()));
 	}
 
 	@Override


### PR DESCRIPTION
Fixed parts not updating their neighbours after disconnecting from them.
Made code a bit more readable and reduced copy-paste usage.

Everything works fine so far, but I am not completely sure.


I added 2 `public final` methods to `CircuitPart`:
* `getCachedInputFromSide` gets input values that gate stores in its property. Used in `getInputFromSide`. Also used to check if neighbour should actually be updated in `notifyNeighbours`, instead of `getInputFromSide` (this fixes #120).
* `hasConnectionOnSide` checks if part is actually connected to anything on specified side. Used in various places to increase code readability.

Also, `PartNull` no longer `canConnect` on any side, and uses standard `onPlaced` handler (it should work properly now).