### PR TITLE
Circuit format version control

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/Constants.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/Constants.java
@@ -3,6 +3,12 @@ package moe.nightfall.vic.integratedcircuits;
 public class Constants {
 	public static final String MOD_ID = "integratedcircuits";
 	public static final String MOD_VERSION = "${version}";
+	
+	// Circuit format versions:
+	//  0 = unnspecified old format, assumed to be 0.8r34 compatible.
+	//  1 = 0.9r34 development versions, before version control introduction.
+	// Current circuit format version:
+	public static final int CURRENT_FORMAT_VERSION = 1;
 
 	public static int GATE_RENDER_ID;
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 
 import moe.nightfall.vic.integratedcircuits.IntegratedCircuits;
+import moe.nightfall.vic.integratedcircuits.api.gate.ISocket.EnumConnectionType;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartIOBit;
 import moe.nightfall.vic.integratedcircuits.cp.part.PartNull;
 import moe.nightfall.vic.integratedcircuits.misc.CraftingAmount;
@@ -485,6 +486,19 @@ public class CircuitData implements Cloneable {
 	public void upgradeFormat() {
 		if (formatVersion < Constants.CURRENT_FORMAT_VERSION) {
 			int version = formatVersion;
+			
+			if (version < 1) {
+				// IO modes were reordered
+				for (int i = 0; i < 4; i++) {
+					EnumConnectionType mode = prop.getModeAtSide(i);
+					if (mode == EnumConnectionType.BUNDLED)
+						prop.setCon(prop.setModeAtSide(i, EnumConnectionType.ANALOG));
+					else if (mode == EnumConnectionType.ANALOG)
+						prop.setCon(prop.setModeAtSide(i, EnumConnectionType.BUNDLED));
+				}
+				
+				version = 1;
+			}
 			
 			// Upgrade all gates in circuit
 			for (int x = 0; x < size; x++) {

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPart.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPart.java
@@ -315,4 +315,10 @@ public abstract class CircuitPart {
 	public Collection<Integer> getSubtypes() {
 		return Collections.emptyList();
 	}
+
+	// Backwards compatibility stuff below this line
+
+	public void onFormatUpgrade(Vec2 pos, ICircuit parent) {
+		System.out.println("Upgrade " + pos);
+	}
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPart.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitPart.java
@@ -319,6 +319,5 @@ public abstract class CircuitPart {
 	// Backwards compatibility stuff below this line
 
 	public void onFormatUpgrade(Vec2 pos, ICircuit parent) {
-		System.out.println("Upgrade " + pos);
 	}
 }


### PR DESCRIPTION
To overcome breaking changes to circuit format.
(See #123 for example)

Tested it on IO mode conversion from 0.8 to 0.9.

**Warning!**
*If you are* **already using 0.9***, the second of these commits* **will change your bundled IO to analog and vice versa**, because I cannot distinguish if circuit is from 0.8 or early 0.9 (before version control), and 0.8 is priority.