### PR TITLE
LegacyLoader for 0.8=>0.9 circuit conversion.

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
@@ -57,12 +57,17 @@ public class CircuitData implements Cloneable {
 	}
 
 	private CircuitData(int size, ICircuit parent, int[][] id, int[][] meta, LinkedHashSet<Vec2> tickSchedule, CircuitProperties prop) {
+		this(size, parent, id, meta, tickSchedule, new LinkedHashSet<Vec2>(), prop);
+	}
+
+	private CircuitData(int size, ICircuit parent, int[][] id, int[][] meta, LinkedHashSet<Vec2> tickSchedule, LinkedHashSet<Vec2> inputQueue, CircuitProperties prop) {
 		this.parent = parent;
 		this.prop = prop;
 		this.size = size;
 		this.id = id;
 		this.meta = meta;
 		this.tickSchedule = tickSchedule;
+		this.inputQueue = inputQueue;
 		this.hasChanged = !isEmpty();
 	}
 
@@ -299,6 +304,10 @@ public class CircuitData implements Cloneable {
 	}
 
 	public synchronized void updateMatrix() {
+		// InputQueue might not be empty between ticks in some rare cases.
+		if (!inputQueue.isEmpty())
+			propagateSignals();
+
 		// Tick all circuit parts that need to be ticked
 		HashSet<Vec2> tmp = (HashSet<Vec2>) tickSchedule.clone();
 		tickSchedule.clear();
@@ -353,7 +362,18 @@ public class CircuitData implements Cloneable {
 			scheduledTicks.add(new Vec2(scheduledList[i], scheduledList[i + 1]));
 		}
 
-		CircuitData cdata = new CircuitData(size, parent, id, meta, scheduledTicks, prop);
+		LinkedHashSet<Vec2> inputQueue = new LinkedHashSet<Vec2>();
+		if (compound.hasKey("inputQueue")) {
+			// Input update queue should be empty between ticks,
+			//  but it might not be in some rare cases.
+			//  (Mostly when circuit was converted from previous version.)
+			int[] inputList = compound.getIntArray("inputQueue");
+			for (int i = 0; i < inputList.length; i += 2) {
+				inputQueue.add(new Vec2(inputList[i], inputList[i + 1]));
+			}
+		}
+
+		CircuitData cdata = new CircuitData(size, parent, id, meta, scheduledTicks, inputQueue, prop);
 
 		if (version < CircuitData.version) {
 			// TODO Not future-proof. Will break if e.g. inputQueue is removed.
@@ -402,6 +422,18 @@ public class CircuitData implements Cloneable {
 			tmp.add(v.y);
 		}
 		compound.setIntArray("scheduled", Ints.toArray(tmp));
+
+		if (!inputQueue.isEmpty()) {
+			// Input update queue should be empty between ticks,
+			//  but it might not be in some rare cases.
+			//  (Mostly when circuit was converted from previous version.)
+			tmp = new LinkedList<Integer>();
+			for (Vec2 v : inputQueue) {
+				tmp.add(v.x);
+				tmp.add(v.y);
+			}
+			compound.setIntArray("inputQueue", Ints.toArray(tmp));
+		}
 
 		compound.setInteger("version", version);
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
@@ -356,6 +356,7 @@ public class CircuitData implements Cloneable {
 		CircuitData cdata = new CircuitData(size, parent, id, meta, scheduledTicks, prop);
 
 		if (version < CircuitData.version) {
+			// TODO Not future-proof. Will break if e.g. inputQueue is removed.
 			for (LegacyLoader loader : legacyLoaders) {
 				loader.postTransform(cdata);
 			}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
@@ -11,30 +11,31 @@ import moe.nightfall.vic.integratedcircuits.cp.CircuitData;
 import moe.nightfall.vic.integratedcircuits.misc.Vec2;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class LegacyLoader implements Comparable<LegacyLoader> {
+public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 
 	private static final List<LegacyLoader> legacyLoaders = new ArrayList<LegacyLoader>();
-
-	public final int version;
-	private Map<Integer, PartTransformer> partTransformers = new HashMap<Integer, PartTransformer>();
-
-	public LegacyLoader(int version) {
-		this.version = version;
-	}
-
-	public static void addLegacyLoader(LegacyLoader loader) {
-		legacyLoaders.add(loader);
+	static {
+		legacyLoaders.add(new LegacyLoader_0_8());
 		Collections.sort(legacyLoaders);
 	}
 
+	private Map<Integer, PartTransformer> partTransformers = new HashMap<Integer, PartTransformer>();
+
+	/** Returns version FROM which it converts.
+	 *  Should always convert to the next version.
+	 **/
+	public abstract int getVersion();
+
 	public static List<LegacyLoader> getLegacyLoaders(int version) {
-		for (int i = 0; i < legacyLoaders.size(); i++) {
+		int i = 0;
+		while (i < legacyLoaders.size()) {
 			LegacyLoader loader = legacyLoaders.get(i);
-			if (loader.version == version) {
-				return legacyLoaders.subList(0, i);
+			if (loader.getVersion() >= version) {
+				break;
 			}
+			i++;
 		}
-		return new ArrayList<LegacyLoader>();
+		return new ArrayList<LegacyLoader>(legacyLoaders.subList(i, legacyLoaders.size()));
 	}
 
 	public final LegacyLoader addTransformer(PartTransformer transformer, int id) {
@@ -43,7 +44,6 @@ public class LegacyLoader implements Comparable<LegacyLoader> {
 	}
 
 	public void transformNBT(NBTTagCompound data) {
-
 	}
 
 	public void transform(int size, int[][] id, int[][] meta) {
@@ -227,6 +227,6 @@ public class LegacyLoader implements Comparable<LegacyLoader> {
 
 	@Override
 	public int compareTo(LegacyLoader other) {
-		return Integer.compare(version, other.version);
+		return Integer.compare(getVersion(), other.getVersion());
 	}
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
@@ -64,7 +64,7 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 			}
 		}
 	}
-	
+
 	public void postTransform(CircuitData cdata) {
 		for (int x = 0; x < cdata.getSize(); x++) {
 			for (int y = 0; y < cdata.getSize(); y++) {
@@ -87,24 +87,22 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 		protected int id;
 		private int meta;
 
-		protected AllocationMap old, transformed;
+		protected AllocationMap old = new AllocationMap(32);
+		protected AllocationMap transformed = new AllocationMap(32);
 		private BitSet oldMeta, transformedMeta;
-
-		protected PartTransformer() {
-			old = new AllocationMap(32);
-			transformed = new AllocationMap(32);
-		}
 
 		public final void transform() {
 			oldMeta = BitSet.valueOf(new long[] { meta });
-			transformedMeta = (BitSet) oldMeta.clone();
-			old.copyTo(transformed, transformedMeta);
+			transformedMeta = new BitSet(32);
 			transformImpl();
-			meta = (int) transformedMeta.toLongArray()[0];
+			// toLongArray is zero length for all-0s bitset
+			meta = transformedMeta.length() == 0 ? 0 : (int) transformedMeta.toLongArray()[0];
 		}
 
 		protected final int getInt(int id) {
-			return (int) old.get(id, oldMeta).toLongArray()[0];
+			BitSet bs = old.get(id, oldMeta);
+			// toLongArray is zero length for all-0s bitset
+			return bs.length() == 0 ? 0 : (int) bs.toLongArray()[0];
 		}
 
 		protected final boolean getBit(int id) {
@@ -123,7 +121,7 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 
 		protected void transformImpl() {
 		}
-		
+
 		public void postTransform(Vec2 crd, CircuitData cdata) {
 		}
 	}
@@ -132,30 +130,69 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 	/*
 	@Test
 	public void test() {
-		PartTransformer transformer = new PartTransformer() {{
+		class BaseTransformer extends PartTransformer {
+			// Conversion: 0bAAAAAxxxx => 0bBBAAAAA
+
+			int oldA, newA, newB;
+			{
 				old.skip(4);
-				old.allocate(0, 5);
-	
-				transformed.allocate(0, 5);
-				transformed.allocate(1, 2);
+				oldA = old.allocate(5);
+
+				newA = transformed.allocate(5);
+				newB = transformed.allocate(2);
 			}
-	
+
 			@Override
 			protected void transformImpl() {
-				setInt(1, 3);
-			}	
+				setInt(newA, getInt(oldA));
+				setInt(newB, 3);
+			}
 		};
 
-		transformer.meta = 0x1F0;
+		PartTransformer transformer = new BaseTransformer();
+
+		transformer.meta = 0x1F0; // 0b111110000
 		transformer.transform();
 
-		assertEquals(0x7F, transformer.meta);
+		assertEquals(0x7F, transformer.meta); // 0b1111111
+
+
+		class DerivedTransformer extends BaseTransformer {
+			// Conversion: 0bEEDCAAAAAxxxx => 0bDEEECBBAAAAA (newE is oldE+1)
+
+			int oldC, oldD, oldE, newC, newD, newE;
+			{
+				oldC = old.allocate();
+				oldD = old.allocate();
+				oldE = old.allocate(2);
+
+				newC = transformed.allocate();
+				newE = transformed.allocate(3);
+				newD = transformed.allocate();
+			}
+
+			@Override
+			protected void transformImpl() {
+				setBit(newC, getBit(oldC));
+				setBit(newD, getBit(oldD));
+				setInt(newE, getInt(oldE) + 1);
+				super.transformImpl();
+			}
+		}
+
+		transformer = new DerivedTransformer();
+
+		transformer.meta = 0x1D55; // 0b1110101010101
+		transformer.transform();
+
+		assertEquals(0xC75, transformer.meta); // 0b110001110101
 	}*/
 
 	public static class AllocationMap {
 
 		protected int index;
 		protected int size;
+		protected int id = 0;
 
 		private Map<Integer, Allocation> allocationMap = new HashMap<Integer, Allocation>();
 
@@ -163,23 +200,20 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 			this.size = size;
 		}
 
-		public AllocationMap skip(int size) {
+		public void skip(int size) {
 			index += size;
 			if (index >= this.size)
 				throw new ArrayIndexOutOfBoundsException();
-			return this;
 		}
 
-		public AllocationMap allocate(int id, int size) {
+		public int allocate(int size) {
 			allocationMap.put(id, new Allocation(index, size));
 			skip(size);
-			return this;
+			return id++;
 		}
 
-		public AllocationMap allocate(int id) {
-			allocationMap.put(id, new Allocation(index, 1));
-			skip(1);
-			return this;
+		public int allocate() {
+			return allocate(1);
 		}
 
 		public void set(int id, BitSet value, BitSet data) {
@@ -194,7 +228,7 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 
 		public BitSet get(int id, BitSet data) {
 			if (!allocationMap.containsKey(id))
-				return new BitSet();
+				throw new ArrayIndexOutOfBoundsException();
 			Allocation allocation = allocationMap.get(id);
 
 			BitSet value = new BitSet(allocation.size);
@@ -202,15 +236,6 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 				value.set(i, data.get(i + allocation.index));
 			}
 			return value;
-		}
-
-		public void copyTo(AllocationMap other, BitSet data) {
-			BitSet data1 = (BitSet) data.clone();
-			data.clear();
-			for (int id : allocationMap.keySet()) {
-				Allocation allocation = allocationMap.get(id);
-				other.set(id, get(id, data1), data);
-			}
 		}
 
 		private static class Allocation {

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader.java
@@ -173,10 +173,10 @@ public abstract class LegacyLoader implements Comparable<LegacyLoader> {
 
 			@Override
 			protected void transformImpl() {
+				super.transformImpl();
 				setBit(newC, getBit(oldC));
 				setBit(newD, getBit(oldD));
 				setInt(newE, getInt(oldE) + 1);
-				super.transformImpl();
 			}
 		}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -65,7 +65,7 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		//addTransformer(new PartTransparentLatchTransformer(), 18);
 		addTransformer(new PartXORGateTransformer(), 19); // PartXORGate
 		addTransformer(new PartXORGateTransformer(), 20); // PartXNORGate
-		//addTransformer(new PartSynchronizerTransformer(), 21);
+		addTransformer(new PartSynchronizerTransformer(), 21);
 		addTransformer(new CircuitPartTransformer(), 22); // PartNullCell
 		addTransformer(new PartIOBitTransformer(), 23);
 		addTransformer(new PartSimpleGateTransformer(), 24); // PartInvertCell
@@ -189,6 +189,33 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 	// PartSynchronizer was derived from PartCPGate in 0.8
 	// It is derived from PartDelayedAction in 0.9
+	private static class PartSynchronizerTransformer extends PartCPGateTransformer {
+		protected final int oldEast = old.allocate();
+		protected final int oldWest = old.allocate();
+		protected final int oldOut = old.allocate();
+
+		protected final int newActive = transformed.allocate();
+		protected final int newCurrentDelay = transformed.allocate(8);
+		protected final int newEast = transformed.allocate();
+		protected final int newWest = transformed.allocate();
+		protected final int newOldEast = transformed.allocate();
+		protected final int newOldWest = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			super.transformImpl();
+			setBit(newEast, getBit(oldEast));
+			setBit(newWest, getBit(oldWest));
+			
+			// Start new delay if output is high
+			setBit(newActive, getBit(oldOut));
+			setInt(newCurrentDelay, 0);
+			
+			// Store current input as "old" (used for edge detection).
+			setBit(newOldEast, getRotatedInput(ForgeDirection.EAST));
+			setBit(newOldWest, getRotatedInput(ForgeDirection.WEST));
+		}
+	}
 
 	// PartToggleLatch
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -1,0 +1,19 @@
+package moe.nightfall.vic.integratedcircuits.cp.legacy;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import moe.nightfall.vic.integratedcircuits.cp.CircuitData;
+import moe.nightfall.vic.integratedcircuits.misc.Vec2;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class LegacyLoader_0_8 extends LegacyLoader {
+	@Override
+	public int getVersion() {
+		return 0;
+	}
+}

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -8,10 +8,13 @@ import java.util.List;
 import java.util.Map;
 
 import moe.nightfall.vic.integratedcircuits.cp.CircuitData;
+import moe.nightfall.vic.integratedcircuits.cp.legacy.LegacyLoader;
+import moe.nightfall.vic.integratedcircuits.misc.MiscUtils;
 import moe.nightfall.vic.integratedcircuits.misc.Vec2;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
 
-public class LegacyLoader_0_8 extends LegacyLoader {
+public final class LegacyLoader_0_8 extends LegacyLoader {
 	@Override
 	public int getVersion() {
 		return 0;
@@ -31,4 +34,245 @@ public class LegacyLoader_0_8 extends LegacyLoader {
 		NBTTagCompound props = data.getCompoundTag("properties");
 		props.setInteger("con", swapBundledAnalog(props.getInteger("con")));
 	}
+
+	/* TODO: This will not work without a valid ICircuit. Not entirely necessary.
+	@Override
+	public void postTransform(CircuitData cdata) {
+		super.postTransform(cdata);
+		cdata.propagateSignals();
+	}
+	*/
+
+	{
+		addTransformer(new CircuitPartTransformer(), 0); // PartNull
+		addTransformer(new PartWireTransformer(), 1);
+		addTransformer(new CircuitPartTransformer(), 2); // PartTorch
+		addTransformer(new Part3I1OTransformer(), 3); // PartANDGate
+		addTransformer(new Part3I1OTransformer(), 4); // PartORGate
+		addTransformer(new Part3I1OTransformer(), 5); // PartNANDGate
+		addTransformer(new Part3I1OTransformer(), 6); // PartNORGate
+		addTransformer(new Part1I3OTransformer(), 7); // PartBufferGate
+		addTransformer(new Part1I3OTransformer(), 8); // PartNOTGate
+		addTransformer(new PartSimpleGateTransformer(), 9); // PartMultiplexer
+		//addTransformer(new PartRepeaterTransformer(), 10);
+		addTransformer(new PartTimerTransformer(), 11);
+		//addTransformer(new PartSequencerTransformer(), 12);
+		//addTransformer(new PartStateCellTransformer(), 13);
+		//addTransformer(new PartRandomizerTransformer(), 14);
+		addTransformer(new PartPulseFormerTransformer(), 15);
+		//addTransformer(new PartRSLatchTransformer(), 16);
+		//addTransformer(new PartToggleLatchTransformer(), 17);
+		//addTransformer(new PartTransparentLatchTransformer(), 18);
+		addTransformer(new PartXORGateTransformer(), 19); // PartXORGate
+		addTransformer(new PartXORGateTransformer(), 20); // PartXNORGate
+		//addTransformer(new PartSynchronizerTransformer(), 21);
+		addTransformer(new CircuitPartTransformer(), 22); // PartNullCell
+		addTransformer(new PartIOBitTransformer(), 23);
+		addTransformer(new PartSimpleGateTransformer(), 24); // PartInvertCell
+		addTransformer(new PartSimpleGateTransformer(), 25); // PartBufferCell
+		addTransformer(new PartSimpleGateTransformer(), 26); // PartANDCell
+		// PartTunnel (27) was not present in 0.8
+	}
+
+	// Part transformers:
+
+	private static class CircuitPartTransformer extends PartTransformer {
+		protected final int oldInput = old.allocate(4);
+		protected final int newInput = transformed.allocate(4);
+		@Override
+		public void transformImpl() {
+			setInt(newInput, getInt(oldInput));
+		}
+
+		@Override
+		public void postTransform(Vec2 pos, CircuitData cdata) {
+			/* TODO: If CircuitData is stored to NBT *before it is ticked* at
+			 *  least once, these scheduled input updates will be dropped, and
+			 *  circuit will just remain glitched if it already was.
+			 * This legacy loader should not introduce any new glitches.
+			 */
+			// Schedule input updates for the whole circuit, to eliminate glitches.
+			// TODO: Uncomment after testing: cdata.scheduleInputChange(pos);
+
+			// Tick the whole circuit once, because many gates might need it.
+			cdata.scheduleTick(pos);
+		}
+
+		protected final boolean getInput(ForgeDirection side) {
+			return (getInt(oldInput) << (side.ordinal() - 2) & 8) != 0;
+		}
+	}
+
+	// CircuitPart descendants:
+
+	// PartTunnel was not present in 0.8
+
+	// PartNull, PartNullCell and PartTorch
+	// add nothing to CircuitPartTransformer
+
+	private static abstract class PartCPGateTransformer extends CircuitPartTransformer {
+		protected final int oldRotation = old.allocate(2);
+		protected final int newRotation = transformed.allocate(2);
+
+		@Override
+		public void transformImpl() {
+			setInt(newRotation, getInt(oldRotation));
+			super.transformImpl();
+		}
+
+		protected final boolean getRotatedInput(ForgeDirection side) {
+			// TODO: This should not break in future, right?
+			return getInput(MiscUtils.rotn(side, getInt(oldRotation)));
+		}
+	}
+
+	private static class PartIOBitTransformer extends CircuitPartTransformer {
+		protected final int oldRotFreq = old.allocate(6);
+		protected final int newRotFreq = transformed.allocate(6);
+
+		@Override
+		public void transformImpl() {
+			setInt(newRotFreq, getInt(oldRotFreq));
+			super.transformImpl();
+		}
+	}
+
+	private static class PartWireTransformer extends CircuitPartTransformer {
+		protected final int oldColor = old.allocate(2);
+		protected final int newColor = transformed.allocate(2);
+
+		@Override
+		public void transformImpl() {
+			setInt(newColor, getInt(oldColor));
+			super.transformImpl();
+		}
+	}
+
+	// PartCPGate descendants:
+
+	private static abstract class PartDelayedActionTransformer extends PartCPGateTransformer {
+		protected final int oldActive = old.allocate();
+		protected final int oldCurrentDelay = old.allocate(8);
+		protected final int newActive = transformed.allocate();
+		protected final int newCurrentDelay = transformed.allocate(8);
+
+		@Override
+		public void transformImpl() {
+			boolean active = getBit(oldActive);
+			int currentDelay = 0;
+			if (active) {
+				currentDelay = getDelay() - getInt(oldCurrentDelay);
+			}
+			setBit(newActive, active);
+			setInt(newCurrentDelay, currentDelay);
+			super.transformImpl();
+		}
+
+		protected abstract int getDelay();
+	}
+
+	// PartRSLatch
+
+	private static class PartSimpleGateTransformer extends PartCPGateTransformer {
+		protected final int oldOut = old.allocate();
+		protected final int oldTmp = old.allocate();
+		protected final int newOut = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			setInt(newOut, getInt(oldTmp));
+			super.transformImpl();
+		}
+	}
+
+	// PartSynchronizer was derived from PartCPGate in 0.8
+	// It is derived from PartDelayedAction in 0.9
+
+	// PartToggleLatch
+
+	// PartTransparentLatch
+
+	// PartDelayedAction descendants:
+
+	private static class PartPulseFormerTransformer extends PartDelayedActionTransformer {
+		protected final int newOldIn = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			setBit(newOldIn, getRotatedInput(ForgeDirection.SOUTH));
+			super.transformImpl();
+		}
+
+		@Override
+		public int getDelay() {
+			return 2;
+		}
+	}
+
+	// PartRandomizer
+
+	// PartRepeater
+
+	// PartSequencer
+
+	// PartStateCell
+
+	private static class PartTimerTransformer extends PartDelayedActionTransformer {
+		protected final int oldOut = old.allocate();
+		protected final int oldDelay = old.allocate(8);
+		protected final int newOut = transformed.allocate();
+		protected final int newDelay = transformed.allocate(8);
+
+		@Override
+		public void transformImpl() {
+			setBit(newOut, getBit(oldOut));
+			setInt(newDelay, getInt(oldDelay));
+			super.transformImpl();
+		}
+
+		@Override
+		public int getDelay() {
+			return getBit(oldOut) ? 2 : getInt(oldDelay);
+		}
+	}
+
+	// PartSimpleGate descendants:
+
+	// PartANDCell, PartBufferCell and PartMultiplexer add nothing
+
+	// This works for all Part1I3O descendants
+	private static class Part1I3OTransformer extends PartSimpleGateTransformer {
+		protected final int oldConnectors = old.allocate(3);
+		protected final int newConnectors = transformed.allocate(3);
+
+		@Override
+		public void transformImpl() {
+			setInt(newConnectors, getInt(oldConnectors));
+			super.transformImpl();
+		}
+	}
+
+	// This works for all Part3I1O descendants
+	private static class Part3I1OTransformer extends PartSimpleGateTransformer {
+		protected final int oldConnectors = old.allocate(2);
+		protected final int newConnectors = transformed.allocate(2);
+
+		@Override
+		public void transformImpl() {
+			setInt(newConnectors, getInt(oldConnectors));
+			super.transformImpl();
+		}
+	}
+
+	// This works for both XOR and XNOR gates. They are Part2I1O in 0.9.
+	private static class PartXORGateTransformer extends PartSimpleGateTransformer {
+		protected final int newConnectors = transformed.allocate(2);
+
+		@Override
+		public void transformImpl() {
+			setInt(newConnectors, 0);
+			super.transformImpl();
+		}
+	}
+
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -116,8 +116,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newRotation, getInt(oldRotation));
 			super.transformImpl();
+			setInt(newRotation, getInt(oldRotation));
 		}
 
 		protected final boolean getRotatedInput(ForgeDirection side) {
@@ -132,8 +132,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newRotFreq, getInt(oldRotFreq));
 			super.transformImpl();
+			setInt(newRotFreq, getInt(oldRotFreq));
 		}
 	}
 
@@ -143,8 +143,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newColor, getInt(oldColor));
 			super.transformImpl();
+			setInt(newColor, getInt(oldColor));
 		}
 	}
 
@@ -158,14 +158,16 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
+			super.transformImpl();
 			boolean active = getBit(oldActive);
 			int currentDelay = 0;
 			if (active) {
 				currentDelay = getDelay() - getInt(oldCurrentDelay);
+				if (currentDelay < 0)
+					currentDelay = 0;
 			}
 			setBit(newActive, active);
 			setInt(newCurrentDelay, currentDelay);
-			super.transformImpl();
 		}
 
 		protected abstract int getDelay();
@@ -180,8 +182,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newOut, getInt(oldTmp));
 			super.transformImpl();
+			setInt(newOut, getInt(oldTmp));
 		}
 	}
 
@@ -199,8 +201,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setBit(newOldIn, getRotatedInput(ForgeDirection.SOUTH));
 			super.transformImpl();
+			setBit(newOldIn, getRotatedInput(ForgeDirection.SOUTH));
 		}
 
 		@Override
@@ -215,8 +217,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setBit(newRandom, getBit(oldRandom));
 			super.transformImpl();
+			setBit(newRandom, getBit(oldRandom));
 		}
 
 		@Override
@@ -233,29 +235,23 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
+			super.transformImpl();
 			int delay = getInt(oldDelay);
 			if (delay != 255)
 				delay -= 1;
 			setBit(newOut, getBit(oldOut));
 			setInt(newDelay, delay);
-			super.transformImpl();
 		}
 
 		@Override
 		public int getDelay() {
-			return getBit(oldOut) ? 2 : getInt(oldDelay);
+			return getInt(oldDelay);
 		}
 	}
 
-	private static class PartSequencerTransformer extends PartCPGateTransformer {
+	private static class PartSequencerTransformer extends PartDelayedActionTransformer {
 		// It was derived from timer in 0.8 and might be in an invalid state,
 		//  because in 0.9 it works exactly as P:R counterpart.
-
-		// PartDelayedAction properties
-		protected final int oldActive = old.allocate();
-		protected final int oldCurrentDelay = old.allocate(8);
-		protected final int newActive = transformed.allocate();
-		protected final int newCurrentDelay = transformed.allocate(8);
 
 		// Old PartTimer and PartSequencer properties
 		protected final int oldOut = old.allocate();
@@ -268,20 +264,21 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			int delay = getInt(oldDelay);
-			
-			// Transform ongonig delay or start new one.
-			// This is normally handled by PartDelayedActionTransformer.
-			// Next tick is scheduled by CircuitPartTransformer for all gates.
-			int currentDelay = 0;
-			if (getBit(oldActive))
-				currentDelay = delay - getInt(oldCurrentDelay);
-			setBit(newActive, true);
-			setInt(newCurrentDelay, currentDelay);
-			
-			setInt(newDelay, delay);
-			setInt(newOutSide, getInt(oldOutSide));
 			super.transformImpl();
+			setInt(newDelay, getInt(oldDelay));
+			setInt(newOutSide, getInt(oldOutSide));
+			
+			// Start new delay if sequencer was stopped.
+			// Next tick is scheduled by CircuitPartTransformer for all gates.
+			if (!getBit(oldActive)) {
+				setBit(newActive, true);
+				setInt(newCurrentDelay, 0);
+			}
+		}
+
+		@Override
+		public int getDelay() {
+			return getInt(oldDelay);
 		}
 	}
 
@@ -295,9 +292,9 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
+			super.transformImpl();
 			setBit(newOut, getBit(oldOut));
 			setInt(newDelay, getInt(oldDelay));
-			super.transformImpl();
 		}
 
 		@Override
@@ -317,8 +314,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newConnectors, getInt(oldConnectors));
 			super.transformImpl();
+			setInt(newConnectors, getInt(oldConnectors));
 		}
 	}
 
@@ -329,8 +326,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newConnectors, getInt(oldConnectors));
 			super.transformImpl();
+			setInt(newConnectors, getInt(oldConnectors));
 		}
 	}
 
@@ -340,8 +337,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void transformImpl() {
-			setInt(newConnectors, 0);
 			super.transformImpl();
+			setInt(newConnectors, 0);
 		}
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -54,11 +54,11 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		addTransformer(new Part1I3OTransformer(), 7); // PartBufferGate
 		addTransformer(new Part1I3OTransformer(), 8); // PartNOTGate
 		addTransformer(new PartSimpleGateTransformer(), 9); // PartMultiplexer
-		//addTransformer(new PartRepeaterTransformer(), 10);
+		addTransformer(new PartRepeaterTransformer(), 10);
 		addTransformer(new PartTimerTransformer(), 11);
 		//addTransformer(new PartSequencerTransformer(), 12);
 		//addTransformer(new PartStateCellTransformer(), 13);
-		//addTransformer(new PartRandomizerTransformer(), 14);
+		addTransformer(new PartRandomizerTransformer(), 14);
 		addTransformer(new PartPulseFormerTransformer(), 15);
 		//addTransformer(new PartRSLatchTransformer(), 16);
 		//addTransformer(new PartToggleLatchTransformer(), 17);
@@ -209,9 +209,43 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		}
 	}
 
-	// PartRandomizer
+	private static class PartRandomizerTransformer extends PartDelayedActionTransformer {
+		protected final int oldRandom = old.allocate(3);
+		protected final int newRandom = transformed.allocate(3);
 
-	// PartRepeater
+		@Override
+		public void transformImpl() {
+			setBit(newRandom, getBit(oldRandom));
+			super.transformImpl();
+		}
+
+		@Override
+		public int getDelay() {
+			return 2;
+		}
+	}
+
+	private static class PartRepeaterTransformer extends PartDelayedActionTransformer {
+		protected final int oldDelay = old.allocate(8);
+		protected final int oldOut = old.allocate();
+		protected final int newDelay = transformed.allocate(8);
+		protected final int newOut = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			int delay = getInt(oldDelay);
+			if (delay != 255)
+				delay -= 1;
+			setBit(newOut, getBit(oldOut));
+			setInt(newDelay, delay);
+			super.transformImpl();
+		}
+
+		@Override
+		public int getDelay() {
+			return getBit(oldOut) ? 2 : getInt(oldDelay);
+		}
+	}
 
 	// PartSequencer
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -56,7 +56,7 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		addTransformer(new PartSimpleGateTransformer(), 9); // PartMultiplexer
 		addTransformer(new PartRepeaterTransformer(), 10);
 		addTransformer(new PartTimerTransformer(), 11);
-		//addTransformer(new PartSequencerTransformer(), 12);
+		addTransformer(new PartSequencerTransformer(), 12);
 		//addTransformer(new PartStateCellTransformer(), 13);
 		addTransformer(new PartRandomizerTransformer(), 14);
 		addTransformer(new PartPulseFormerTransformer(), 15);
@@ -247,7 +247,43 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		}
 	}
 
-	// PartSequencer
+	private static class PartSequencerTransformer extends PartCPGateTransformer {
+		// It was derived from timer in 0.8 and might be in an invalid state,
+		//  because in 0.9 it works exactly as P:R counterpart.
+
+		// PartDelayedAction properties
+		protected final int oldActive = old.allocate();
+		protected final int oldCurrentDelay = old.allocate(8);
+		protected final int newActive = transformed.allocate();
+		protected final int newCurrentDelay = transformed.allocate(8);
+
+		// Old PartTimer and PartSequencer properties
+		protected final int oldOut = old.allocate();
+		protected final int oldDelay = old.allocate(8);
+		protected final int oldOutSide = old.allocate(2);
+
+		// New PartSequencer properties
+		protected final int newOutSide = transformed.allocate(2);
+		protected final int newDelay = transformed.allocate(8);
+
+		@Override
+		public void transformImpl() {
+			int delay = getInt(oldDelay);
+			
+			// Transform ongonig delay or start new one.
+			// This is normally handled by PartDelayedActionTransformer.
+			// Next tick is scheduled by CircuitPartTransformer for all gates.
+			int currentDelay = 0;
+			if (getBit(oldActive))
+				currentDelay = delay - getInt(oldCurrentDelay);
+			setBit(newActive, true);
+			setInt(newCurrentDelay, currentDelay);
+			
+			setInt(newDelay, delay);
+			setInt(newOutSide, getInt(oldOutSide));
+			super.transformImpl();
+		}
+	}
 
 	// PartStateCell
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -57,7 +57,7 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		addTransformer(new PartRepeaterTransformer(), 10);
 		addTransformer(new PartTimerTransformer(), 11);
 		addTransformer(new PartSequencerTransformer(), 12);
-		//addTransformer(new PartStateCellTransformer(), 13);
+		addTransformer(new PartStateCellTransformer(), 13);
 		addTransformer(new PartRandomizerTransformer(), 14);
 		addTransformer(new PartPulseFormerTransformer(), 15);
 		//addTransformer(new PartRSLatchTransformer(), 16);
@@ -282,7 +282,35 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		}
 	}
 
-	// PartStateCell
+	private static class PartStateCellTransformer extends PartDelayedActionTransformer {
+		protected final int oldDelay = old.allocate(8);
+		protected final int oldOutWest = old.allocate();
+		protected final int oldOutNorth = old.allocate();
+		protected final int newDelay = transformed.allocate(8);
+		protected final int newOutWest = transformed.allocate();
+		protected final int newOutNorth = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			super.transformImpl();
+			setInt(newDelay, getInt(oldDelay));
+			if (getRotatedInput(ForgeDirection.SOUTH)) {
+				// Fix possibly invalid state
+				setBit(newOutWest, true);
+				setBit(newOutNorth, false);
+				setBit(newActive, false);
+				setInt(newCurrentDelay, 0);
+			} else {
+				setBit(newOutWest, getBit(oldOutWest));
+				setBit(newOutNorth, getBit(oldOutNorth));
+			}
+		}
+
+		@Override
+		public int getDelay() {
+			return getBit(oldOutNorth) ? 2 : getInt(oldDelay);
+		}
+	}
 
 	private static class PartTimerTransformer extends PartDelayedActionTransformer {
 		protected final int oldOut = old.allocate();

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -16,4 +16,19 @@ public class LegacyLoader_0_8 extends LegacyLoader {
 	public int getVersion() {
 		return 0;
 	}
+
+	private int swapBundledAnalog(int con) {
+		// Analog is 1 (0b01), Bundled is 2 (0b10)
+		// In 0.8 it was the other way around, so swap 0b01 and 0b10
+		int mask = (con ^ (con << 1)) & 0xAA; // 0b10101010 is unsupported :(
+		mask |= mask >> 1; // Build mask with all sides to change
+		return con ^ mask; // Change them!
+	}
+
+	@Override
+	public void transformNBT(NBTTagCompound data) {
+		// Swap analog and bundled IO modes
+		NBTTagCompound props = data.getCompoundTag("properties");
+		props.setInteger("con", swapBundledAnalog(props.getInteger("con")));
+	}
 }

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -35,16 +35,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		props.setInteger("con", swapBundledAnalog(props.getInteger("con")));
 	}
 
-	/* TODO: This will not work without a valid ICircuit. Not entirely necessary.
-	@Override
-	public void postTransform(CircuitData cdata) {
-		super.postTransform(cdata);
-		cdata.propagateSignals();
-	}
-	*/
-
 	{
-		addTransformer(new CircuitPartTransformer(), 0); // PartNull
+		// PartNull does not require any meaningful transformation
 		addTransformer(new PartWireTransformer(), 1);
 		addTransformer(new CircuitPartTransformer(), 2); // PartTorch
 		addTransformer(new Part3I1OTransformer(), 3); // PartANDGate
@@ -86,13 +78,8 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 
 		@Override
 		public void postTransform(Vec2 pos, CircuitData cdata) {
-			/* TODO: If CircuitData is stored to NBT *before it is ticked* at
-			 *  least once, these scheduled input updates will be dropped, and
-			 *  circuit will just remain glitched if it already was.
-			 * This legacy loader should not introduce any new glitches.
-			 */
 			// Schedule input updates for the whole circuit, to eliminate glitches.
-			// TODO: Uncomment after testing: cdata.scheduleInputChange(pos);
+			cdata.scheduleInputChange(pos);
 
 			// Tick the whole circuit once, because many gates might need it.
 			cdata.scheduleTick(pos);
@@ -106,9 +93,9 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 	// CircuitPart descendants:
 
 	// PartTunnel was not present in 0.8
+	// PartNull does not require any meaningful transformation
 
-	// PartNull, PartNullCell and PartTorch
-	// add nothing to CircuitPartTransformer
+	// PartNullCell and PartTorch add nothing to CircuitPartTransformer
 
 	private static abstract class PartCPGateTransformer extends CircuitPartTransformer {
 		protected final int oldRotation = old.allocate(2);

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/legacy/LegacyLoader_0_8.java
@@ -60,9 +60,9 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		addTransformer(new PartStateCellTransformer(), 13);
 		addTransformer(new PartRandomizerTransformer(), 14);
 		addTransformer(new PartPulseFormerTransformer(), 15);
-		//addTransformer(new PartRSLatchTransformer(), 16);
-		//addTransformer(new PartToggleLatchTransformer(), 17);
-		//addTransformer(new PartTransparentLatchTransformer(), 18);
+		addTransformer(new PartRSLatchTransformer(), 16);
+		addTransformer(new PartToggleLatchTransformer(), 17);
+		addTransformer(new PartTransparentLatchTransformer(), 18);
 		addTransformer(new PartXORGateTransformer(), 19); // PartXORGate
 		addTransformer(new PartXORGateTransformer(), 20); // PartXNORGate
 		addTransformer(new PartSynchronizerTransformer(), 21);
@@ -173,7 +173,23 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		protected abstract int getDelay();
 	}
 
-	// PartRSLatch
+	private static class PartRSLatchTransformer extends PartCPGateTransformer {
+		protected final int oldOut = old.allocate();
+		protected final int oldTmp = old.allocate();
+		protected final int oldMode = old.allocate(2);
+		
+		protected final int newState = transformed.allocate(2);
+		protected final int newCheck = transformed.allocate();
+		protected final int newMode = transformed.allocate(2);
+
+		@Override
+		public void transformImpl() {
+			super.transformImpl();
+			setInt(newMode, getInt(oldMode));
+			setBit(newCheck, false);
+			setInt(newState, getBit(oldOut) ? 1 : 2);
+		}
+	}
 
 	private static class PartSimpleGateTransformer extends PartCPGateTransformer {
 		protected final int oldOut = old.allocate();
@@ -217,9 +233,37 @@ public final class LegacyLoader_0_8 extends LegacyLoader {
 		}
 	}
 
-	// PartToggleLatch
+	private static class PartToggleLatchTransformer extends PartCPGateTransformer {
+		protected final int oldOut = old.allocate();
+		protected final int oldTmp = old.allocate();
+		
+		protected final int newOut = transformed.allocate();
+		protected final int newOldNorth = transformed.allocate();
+		protected final int newOldSouth = transformed.allocate();
 
-	// PartTransparentLatch
+		@Override
+		public void transformImpl() {
+			super.transformImpl();
+			setBit(newOut, getBit(oldOut));
+			
+			// Store current input as "old" (used for edge detection).
+			setBit(newOldNorth, getRotatedInput(ForgeDirection.NORTH));
+			setBit(newOldSouth, getRotatedInput(ForgeDirection.SOUTH));
+		}
+	}
+
+	private static class PartTransparentLatchTransformer extends PartCPGateTransformer {
+		protected final int oldOut = old.allocate();
+		protected final int oldTmp = old.allocate();
+		
+		protected final int newOut = transformed.allocate();
+
+		@Override
+		public void transformImpl() {
+			super.transformImpl();
+			setBit(newOut, getBit(oldOut));
+		}
+	}
 
 	// PartDelayedAction descendants:
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/timed/PartRandomizer.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/timed/PartRandomizer.java
@@ -58,11 +58,19 @@ public class PartRandomizer extends PartDelayedAction {
 
 	@Override
 	public void onScheduledTick(Vec2 pos, ICircuit parent) {
-		super.onScheduledTick(pos, parent);
 		if (!getInputFromSide(pos, parent, toExternal(pos, parent, ForgeDirection.SOUTH))) {
+			// Do not call super() if input is low,
+			//  to prevent output change on the same tick when it goes low.
 			setDelay(pos, parent, false);
-		} else if (!isDelayActive(pos, parent))
-			setDelay(pos, parent, true);
+		} else {
+			super.onScheduledTick(pos, parent); // Handle delay countdown
+			if (!isDelayActive(pos, parent))
+				// Input went high on this tick.
+				// Change random output right now to respect 1-tick input pulses.
+				// Output still changes at most once in 2 ticks.
+				// This also schedules the next delay.
+				onDelay(pos, parent);
+		}
 	}
 
 	@Override

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/timed/PartRepeater.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/timed/PartRepeater.java
@@ -73,7 +73,10 @@ public class PartRepeater extends PartDelayedAction {
 
 	@Override
 	public void onScheduledTick(Vec2 pos, ICircuit parent) {
+		// Check if onDelay is still to be triggered (even on *current* tick),
+		//  to avoid sampling input before output takes any effect.
 		boolean checkInput = !isDelayActive(pos, parent);
+		
 		super.onScheduledTick(pos, parent);
 		if (checkInput && getProperty(pos, parent, PROP_OUT) !=
 				getInputFromSide(pos, parent,


### PR DESCRIPTION
I had to modify `AllocationMap` to behave more like `PropertyStitcher`, to allow extending `PartTransformer`s (a-la `cp/part` hierarchy).

Also, `inputQueue` is now stored to NBT if it is *not* empty (it normally is), so input changes scheduled on conversion are never lost.