### PR TITLE
Made output updates synchronized. Fixed #135

### DIFF
--- a/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/component/GuiIO.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/client/gui/component/GuiIO.java
@@ -51,7 +51,7 @@ public class GuiIO extends GuiButton implements IHoverable {
 
 		ForgeDirection dir = MiscUtils.getDirection(side);
 		isActive = te.getCircuitData().getProperties().getModeAtSide(side) != EnumConnectionType.SIMPLE || color == 0;
-		boolean isPowered = isActive && te.getInputFromSide(dir, color) || te.getOutputToSide(dir, color);
+		boolean isPowered = isActive && te.getExternalInputFromSide(dir, color) || te.getOutputToSide(dir, color);
 
 		if (isActive) {
 			if (isPowered)
@@ -85,7 +85,7 @@ public class GuiIO extends GuiButton implements IHoverable {
 		boolean b = super.mousePressed(mc, par1, par2) && !parent.blockMouseInput;
 		if (b) {
 			ForgeDirection dir = MiscUtils.getDirection(side);
-			te.setInputFromSide(dir, color, !te.getInputFromSide(dir, color));
+			te.setExternalInputFromSide(dir, color, !te.getExternalInputFromSide(dir, color));
 		}
 		return b;
 	}
@@ -101,7 +101,7 @@ public class GuiIO extends GuiButton implements IHoverable {
 		if (isActive) {
 			text.add("I: "
 					+ I18n.format("gui.integratedcircuits.cad.mode."
-							+ (te.getInputFromSide(dir, color) ? "high" : "low")));
+							+ (te.getExternalInputFromSide(dir, color) ? "high" : "low")));
 			text.add("O: "
 					+ I18n.format("gui.integratedcircuits.cad.mode."
 							+ (te.getOutputToSide(dir, color) ? "high" : "low")));

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/CircuitData.java
@@ -196,10 +196,10 @@ public class CircuitData implements Cloneable {
 			PartIOBit io3 = (PartIOBit) getPart(pos3);
 			PartIOBit io4 = (PartIOBit) getPart(pos4);
 
-			io1.onInputChange(pos1, parent);
-			io2.onInputChange(pos2, parent);
-			io3.onInputChange(pos3, parent);
-			io4.onInputChange(pos4, parent);
+			io1.updateExternalOutput(pos1, parent);
+			io2.updateExternalOutput(pos2, parent);
+			io3.updateExternalOutput(pos3, parent);
+			io4.updateExternalOutput(pos4, parent);
 		}
 	}
 

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/PartIOBit.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/cp/part/PartIOBit.java
@@ -56,6 +56,12 @@ public class PartIOBit extends CircuitPart {
 		setProperty(pos, parent, PROP_FREQUENCY, frequency);
 	}
 
+	public final void updateExternalOutput(Vec2 pos, ICircuit parent) {
+		ForgeDirection dir = MiscUtils.getDirection(getRotation(pos, parent));
+		parent.setOutputToSide(dir, getFrequency(pos, parent),
+				getInputFromSide(pos, parent, dir.getOpposite()));
+	}
+
 	public boolean canConnectToSide(Vec2 pos, ICircuit parent, ForgeDirection side) {
 		ForgeDirection dir = MiscUtils.getDirection(getRotation(pos, parent));
 		return side == dir.getOpposite();
@@ -63,10 +69,14 @@ public class PartIOBit extends CircuitPart {
 
 	@Override
 	public void onInputChange(Vec2 pos, ICircuit parent) {
-		ForgeDirection dir = MiscUtils.getDirection(getRotation(pos, parent));
-		parent.setOutputToSide(dir, getFrequency(pos, parent),
-				getInputFromSide(pos, parent, dir.getOpposite()));
+		scheduleTick(pos, parent);
 		notifyNeighbours(pos, parent);
+	}
+
+	@Override
+	public void onScheduledTick(Vec2 pos, ICircuit parent) {
+		updateExternalOutput(pos, parent);
+		notifyNeighbours(pos, parent); // Implicit updateExternalInput
 	}
 
 	@Override

--- a/src/main/java/moe/nightfall/vic/integratedcircuits/tile/TileEntityCAD.java
+++ b/src/main/java/moe/nightfall/vic/integratedcircuits/tile/TileEntityCAD.java
@@ -80,9 +80,13 @@ public class TileEntityCAD extends TileEntityContainer implements ICircuit, IDis
 		compound.setTag("floppyStack", stackCompound);
 	}
 
+	public final boolean getExternalInputFromSide(ForgeDirection dir, int frequency) {
+		return (in[MiscUtils.getSide(dir)] & 1 << frequency) != 0;
+	}
+
 	@Override
 	public boolean getInputFromSide(ForgeDirection dir, int frequency) {
-		return (in[MiscUtils.getSide(dir)] & 1 << frequency) != 0;
+		return getExternalInputFromSide(dir, frequency) && !getOutputToSide(dir, frequency);
 	}
 
 	public boolean getOutputToSide(ForgeDirection dir, int frequency) {
@@ -90,7 +94,7 @@ public class TileEntityCAD extends TileEntityContainer implements ICircuit, IDis
 	}
 
 	@SideOnly(Side.CLIENT)
-	public void setInputFromSide(ForgeDirection dir, int frequency, boolean output) {
+	public final void setExternalInputFromSide(ForgeDirection dir, int frequency, boolean output) {
 		EnumConnectionType mode = circuitData.getProperties().getModeAtSide(MiscUtils.getSide(dir));
 		if (mode != EnumConnectionType.SIMPLE || frequency == 0) {
 			int[] i = this.in.clone();


### PR DESCRIPTION
I made PartIOBit update circuit IO synchronously (on ticks).
It makes 0-tick output pulses impossible.

However, when a wire is currently powering IO pin and the same IO pin is powered from outside, turning this wire off will keep it off for a whole tick, and only after that IO pin will power it.
